### PR TITLE
Feature/#01/level

### DIFF
--- a/src/test/kotlin/heispirate/cattower/levelTest/ExpTest.kt
+++ b/src/test/kotlin/heispirate/cattower/levelTest/ExpTest.kt
@@ -77,4 +77,62 @@ class ExpTest @Autowired constructor(private val mainUserRepository: MainUserRep
         result.todayExperience shouldBe 200
         result.level shouldBe 8
     }
+
+    @Test
+    fun userExpDecreaseTest() {
+        // given
+        val userId = 1L
+        val user = MainUser(
+            todayExperience = 50,
+            experience = 100,
+            level = 6,
+            aboutMe = null,
+            email = "zzz",
+            nickname = "zzzz",
+            password = "1234",
+            phoneNumber = "12345",
+            providerId = "kakao",
+            provider = "ka"
+        )
+        mainUserRepository.saveAndFlush(user)
+        val expToLose = 50
+
+        // when
+        levelService.loseExp(expToLose, userId)
+        val result = mainUserRepository.findByIdOrNull(userId) ?: throw Exception("user 미확인")
+
+        // then
+        result.experience shouldBe 50
+        result.todayExperience shouldBe 0
+        result.level shouldBe 5
+    }
+
+    @Test
+    fun userExpDecreaseNoLevelDownTest() {
+        // given
+        val userId = 1L
+        val user = MainUser(
+            todayExperience = 50,
+            experience = 100,
+            level = 6,
+            aboutMe = null,
+            email = "zzz",
+            nickname = "zzzz",
+            password = "1234",
+            phoneNumber = "12345",
+            providerId = "kakao",
+            provider = "ka"
+        )
+        mainUserRepository.saveAndFlush(user)
+        val expToLose = 20
+
+        // when
+        levelService.loseExp(expToLose, userId)
+        val result = mainUserRepository.findByIdOrNull(userId) ?: throw Exception("user 미확인")
+
+        // then
+        result.experience shouldBe 80
+        result.todayExperience shouldBe 30
+        result.level shouldBe 6
+    }
 }


### PR DESCRIPTION
## 이슈번호
- closes #1 

## 작업 내용
- loseExp 로직 완성
- levelUp 로직 변경 -> changeLevel
- user찾기 메서드 생성
- 변경 사항들에 따른 gainExp,loseExp 변경
- loseExp를 위한 테스트 코드 추가

## 설명 해주세요
- 경험치를 회수할 상황을 위한 loseExp 로직 생성 (정책에 따라 사용되지 않을 수 있음)
- mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("mainUser", userId) 부분이 중복되어 하나의 메서드로 만들어 호출
- levelUp 로직을 changeLevel로직으로 변경, 변경 사유는 하나의 로직으로 up,down을 모두 처리하기 위함
- issue에 컨트롤러 생성 목표가 있었는데, MainUser에서 조회하는 컨트롤러를 생성하는게 맞다고 생각하여 현재는 만들지 않음

## 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트를 했나요(코드/ 물리)?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 주석을 지웠나요?
