### PR TITLE
Refactor/#03/base entity

### DIFF
--- a/src/main/kotlin/heispirate/cattower/CatTowerApplication.kt
+++ b/src/main/kotlin/heispirate/cattower/CatTowerApplication.kt
@@ -2,8 +2,10 @@ package heispirate.cattower
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
+@EnableJpaAuditing
 class CatTowerApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/heispirate/cattower/domain/admin/model/Admin.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/model/Admin.kt
@@ -1,13 +1,10 @@
 package heispirate.cattower.domain.admin.model
 
 import heispirate.cattower.domain.mainUser.model.MainUser
-import heispirate.cattower.infra.BaseTimeEntity
+import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 
@@ -21,8 +18,6 @@ class Admin(
     @OneToOne(fetch = FetchType.LAZY)
     val mainUser: MainUser,
 
-):BaseTimeEntity() {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null
+):BaseEntity() {
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/authCode/model/AuthCode.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/authCode/model/AuthCode.kt
@@ -1,11 +1,8 @@
 package heispirate.cattower.domain.authCode.model
 
-import heispirate.cattower.infra.BaseTimeEntity
+import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.time.LocalDateTime
 
@@ -24,8 +21,6 @@ class AuthCode(
     @Column(name = "requestNumber")
     var requestNumber : Int,
 
-):BaseTimeEntity() {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null
+):BaseEntity() {
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/chat/model/Chat.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/chat/model/Chat.kt
@@ -1,13 +1,10 @@
 package heispirate.cattower.domain.chat.model
 
 import heispirate.cattower.domain.mainUser.model.MainUser
-import heispirate.cattower.infra.BaseTimeEntity
+import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
@@ -33,8 +30,5 @@ class Chat(
     @JoinColumn(name = "chatRoomId")
     val chatRoom: ChatRoom,
 
-) : BaseTimeEntity() {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null
+) : BaseEntity() {
 }

--- a/src/main/kotlin/heispirate/cattower/domain/chat/model/ChatRoom.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/chat/model/ChatRoom.kt
@@ -2,7 +2,7 @@ package heispirate.cattower.domain.chat.model
 
 import heispirate.cattower.domain.mainUser.model.MainUser
 import heispirate.cattower.domain.post.model.Post
-import heispirate.cattower.infra.BaseTimeEntity
+import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
@@ -25,10 +25,6 @@ class ChatRoom(
     @JoinColumn(name = "post", updatable = false)
     val post: Post,
 
-    ):BaseTimeEntity() {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long? = null
+    ):BaseEntity() {
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/comment/model/Comment.kt
@@ -2,13 +2,10 @@ package heispirate.cattower.domain.comment.model
 
 import heispirate.cattower.domain.petProfile.model.PetProfile
 import heispirate.cattower.domain.post.model.Post
-import heispirate.cattower.infra.BaseTimeEntity
+import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
@@ -33,8 +30,6 @@ class Comment(
     @JoinColumn(name = "petProfileId")
     val petProfile: PetProfile,
 
-) : BaseTimeEntity() {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null
+) : BaseEntity() {
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/comment/model/SubComment.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/comment/model/SubComment.kt
@@ -1,13 +1,10 @@
 package heispirate.cattower.domain.comment.model
 
 import heispirate.cattower.domain.petProfile.model.PetProfile
-import heispirate.cattower.infra.BaseTimeEntity
+import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
@@ -32,8 +29,6 @@ class SubComment(
     @JoinColumn(name = "petProfileId")
     val petProfile: PetProfile,
 
-    ) : BaseTimeEntity() {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null
+    ) : BaseEntity() {
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/likes/model/Likes.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/likes/model/Likes.kt
@@ -4,12 +4,9 @@ import heispirate.cattower.domain.comment.model.Comment
 import heispirate.cattower.domain.comment.model.SubComment
 import heispirate.cattower.domain.petProfile.model.PetProfile
 import heispirate.cattower.domain.post.model.Post
-import heispirate.cattower.infra.BaseTimeEntity
+import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
@@ -33,8 +30,6 @@ class Likes(
     @JoinColumn(name = "SubCommentId")
     val subComment: SubComment?
 
-) : BaseTimeEntity() {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null
+) : BaseEntity() {
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/mainUser/model/MainUser.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/mainUser/model/MainUser.kt
@@ -1,11 +1,8 @@
 package heispirate.cattower.domain.mainUser.model
 
-import heispirate.cattower.infra.BaseTimeEntity
+import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 
 @Table(name = "mainUser")
@@ -41,9 +38,6 @@ class MainUser(
     @Column(name = "providerId")
     val providerId: String?,
 
-    ) : BaseTimeEntity() {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null
+    ) : BaseEntity() {
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/model/PetProfile.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/model/PetProfile.kt
@@ -1,15 +1,12 @@
 package heispirate.cattower.domain.petProfile.model
 
 import heispirate.cattower.domain.mainUser.model.MainUser
-import heispirate.cattower.infra.BaseTimeEntity
+import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
@@ -59,8 +56,6 @@ class PetProfile(
     @JoinColumn(name = "mainUserId")
     val mainUser: MainUser,
 
-    ) : BaseTimeEntity() {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null
+    ) : BaseEntity() {
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/post/model/Post.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/model/Post.kt
@@ -1,7 +1,7 @@
 package heispirate.cattower.domain.post.model
 
 import heispirate.cattower.domain.petProfile.model.PetProfile
-import heispirate.cattower.infra.BaseTimeEntity
+import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.CollectionTable
 import jakarta.persistence.Column
 import jakarta.persistence.ElementCollection
@@ -9,9 +9,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
@@ -44,8 +41,6 @@ class Post(
     @JoinColumn(name = "petProfileId")
     val petProfile : PetProfile
 
-) : BaseTimeEntity() {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null
+) : BaseEntity() {
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/socialUser/model/SocialUser.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/socialUser/model/SocialUser.kt
@@ -1,13 +1,10 @@
 package heispirate.cattower.domain.socialUser.model
 
-import heispirate.cattower.infra.BaseTimeEntity
+import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 
 @Table(name = "socialUser")
@@ -26,8 +23,6 @@ class SocialUser(
     @Column(name = "email")
     val email : String,
 
-): BaseTimeEntity() {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null
+): BaseEntity() {
+
 }

--- a/src/main/kotlin/heispirate/cattower/infra/BaseEntity.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/BaseEntity.kt
@@ -13,7 +13,7 @@ import java.time.LocalDateTime
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
-abstract class BaseTimeEntity {
+abstract class BaseEntity {
     @CreatedDate
     @Column(nullable = false, updatable = false)
     var createdAt: LocalDateTime = LocalDateTime.now()

--- a/src/main/kotlin/heispirate/cattower/infra/BaseTimeEntity.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/BaseTimeEntity.kt
@@ -2,6 +2,9 @@ package heispirate.cattower.infra
 
 import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
@@ -23,4 +26,8 @@ abstract class BaseTimeEntity {
 
     @Column(nullable = true)
     var deletedAt: LocalDateTime? = null
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
 }


### PR DESCRIPTION
## 이슈번호
- closes #3 

## 작업 내용
- BaseTimeEntity에 'Id' 추가
- BaseTimeEntity -> BaseEntity 클래스명 변경
- BaseEntity를 상속받는 각 도메인 Entity에서 'Id' 삭제
- CatTowerApplication에 @EnableJpaAuditing Annotation추가

## 설명 해주세요
- 모든 도메인 Entity에서 Id 컬럼을 사용하고 있는데, BaseEntity 추상클래스에서 상속 받아 Entity 내의 코드 중복을 줄이려 합니다. 

## 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트를 했나요(코드/ 물리)?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 주석을 지웠나요?
