### PR TITLE
Feature/#10/admin

### DIFF
--- a/src/main/kotlin/heispirate/cattower/domain/admin/model/Admin.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/model/Admin.kt
@@ -4,6 +4,8 @@ import heispirate.cattower.domain.mainUser.model.MainUser
 import heispirate.cattower.infra.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
@@ -12,12 +14,13 @@ import jakarta.persistence.Table
 @Entity
 class Admin(
 
-    @Column(name = "role")
-    var role : String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category")
+    var role: Role,
 
     @OneToOne(fetch = FetchType.LAZY)
     val mainUser: MainUser,
 
-):BaseEntity() {
+    ):BaseEntity() {
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/admin/model/Role.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/model/Role.kt
@@ -1,0 +1,9 @@
+package heispirate.cattower.domain.admin.model
+
+enum class Role {
+    DAILY_LIFE_MANAGER, // 일상 게시판 관리자
+    INFORMATION_MANAGER, // 정보 게시판 관리자
+    QUESTION_MANAGER, // 질문 게시판 관리자
+    SHARING_MANAGER, // 나눔 게시판 관리자
+    ADMIN // 모든 게시판 및 기능을 관리하는 관리자
+}

--- a/src/main/kotlin/heispirate/cattower/domain/post/model/Category.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/model/Category.kt
@@ -1,5 +1,8 @@
 package heispirate.cattower.domain.post.model
 
 enum class Category {
-    FREE , QUESTION , TIP , NOTICE , DISTRIBUTE
+    DAILY_LIFE, // 일상
+    INFORMATION, // 정보
+    QUESTION, // 질문
+    SHARING // 나눔
 }

--- a/src/main/kotlin/heispirate/cattower/domain/post/model/Post.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/model/Post.kt
@@ -34,6 +34,10 @@ class Post(
     @Column(name = "category")
     var category : Category,
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "subCategory")
+    var subCategory: SubCategory,
+
     @Column(name = "writer")
     val writer : String,
 

--- a/src/main/kotlin/heispirate/cattower/domain/post/model/SubCategory.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/model/SubCategory.kt
@@ -1,0 +1,28 @@
+package heispirate.cattower.domain.post.model
+
+enum class SubCategory(val category: Category) {
+    // DailyLife
+    GOOD_THINGS(Category.DAILY_LIFE), // 좋은일
+    BAD_THINGS(Category.DAILY_LIFE), // 나쁜일
+    CHAT(Category.DAILY_LIFE), // 잡담
+    SHOW_LOVE(Category.DAILY_LIFE), // 이뻐해주세요
+
+    // Information
+    FOOD_INFO(Category.INFORMATION), // 먹이
+    SNACKS_INFO(Category.INFORMATION), // 간식
+    HEALTH_INFO(Category.INFORMATION), // 건강
+    CARE_INFO(Category.INFORMATION), // 관리
+    PLAY_INFO(Category.INFORMATION), // 놀이
+    TRAINING_INFO(Category.INFORMATION), // 교육
+
+    // Question
+    FOOD_QUESTION(Category.QUESTION), // 먹이
+    SNACKS_QUESTION(Category.QUESTION), // 간식
+    HEALTH_QUESTION(Category.QUESTION), // 건강
+    CARE_QUESTION(Category.QUESTION), // 관리
+    PLAY_QUESTION(Category.QUESTION), // 놀이
+    TRAINING_QUESTION(Category.QUESTION), // 교육
+
+    // Sharing
+    SUPPLIES(Category.SHARING), // 용품
+}


### PR DESCRIPTION
## 이슈번호
#10 

## 작업 내용
- post enum class 변경 및 admin role 추가

## 설명 해주세요
- post의 category를 게시판 분류로 활용하기 위하여 변경
- subcategory를 추가하여 말머리 기능으로 사용
- admin role을 enum class로 변경하여 각 게시판 관리자와,총괄관리자로 분류

이렇게 작업 할 경우 댓글/대댓글 에도 category가 필요해 보이는데 , 현재 방식에 대해서 의견 부탁드립니다.

## 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트를 했나요(코드/ 물리)?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 주석을 지웠나요?
