### PR TITLE
Admin Check 기능

### DIFF
--- a/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminRequestDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminRequestDTO.kt
@@ -1,6 +1,0 @@
-package heispirate.cattower.domain.admin.dto
-
-//data class AdminRequestDTO(
-//    //TODO 필요한 내용 채우기
-//    val
-//)

--- a/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminRequestDTOver1.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminRequestDTOver1.kt
@@ -1,0 +1,9 @@
+package heispirate.cattower.domain.admin.dto
+
+import heispirate.cattower.domain.admin.model.Role
+
+data class AdminRequestDTOver1(
+    val role: Role,
+    val adminEmail: String,
+    val userEmail : String,
+)

--- a/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminResponseDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminResponseDTO.kt
@@ -1,0 +1,15 @@
+package heispirate.cattower.domain.admin.dto
+
+import heispirate.cattower.domain.mainUser.model.MainUser
+
+data class AdminResponseDTO(
+    val email: String
+) {
+    companion object {
+        fun fromMainUser(user: MainUser): AdminResponseDTO {
+            return AdminResponseDTO(
+                email = user.email
+            )
+        }
+    }
+}

--- a/src/main/kotlin/heispirate/cattower/domain/admin/repository/AdminRepository.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/repository/AdminRepository.kt
@@ -4,4 +4,5 @@ import heispirate.cattower.domain.admin.model.Admin
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AdminRepository: JpaRepository<Admin,Long> , CustomAdminRepository {
+    fun findByMainUserEmail(email: String): Admin?
 }

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
@@ -1,7 +1,7 @@
 package heispirate.cattower.domain.admin.service
 
+import heispirate.cattower.infra.category.CategoryInterface
+
 interface AdminService {
-    fun checkAdmin() {
-        //TODO
-    }
+    fun checkAdmin(email: String, categorySelect: CategoryInterface): Boolean
 }

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
@@ -1,7 +1,13 @@
 package heispirate.cattower.domain.admin.service
 
+import heispirate.cattower.domain.admin.dto.AdminRequestDTOver1
+import heispirate.cattower.domain.admin.dto.AdminResponseDTO
 import heispirate.cattower.infra.category.Category
 
 interface AdminService {
     fun checkAdmin(email: String, categorySelect: Category): Boolean
+
+    fun changeUserToAdminVersion1(request: AdminRequestDTOver1): AdminResponseDTO
+
+    fun signInAdmin()
 }

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
@@ -1,7 +1,7 @@
 package heispirate.cattower.domain.admin.service
 
-import heispirate.cattower.infra.category.CategoryInterface
+import heispirate.cattower.infra.category.Category
 
 interface AdminService {
-    fun checkAdmin(email: String, categorySelect: CategoryInterface): Boolean
+    fun checkAdmin(email: String, categorySelect: Category): Boolean
 }

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
@@ -1,4 +1,7 @@
 package heispirate.cattower.domain.admin.service
 
 interface AdminService {
+    fun checkAdmin() {
+        //TODO
+    }
 }

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminServiceImpl.kt
@@ -1,7 +1,42 @@
 package heispirate.cattower.domain.admin.service
 
+import heispirate.cattower.domain.admin.model.Role
+import heispirate.cattower.domain.admin.repository.AdminRepository
+import heispirate.cattower.domain.petProfile.model.PetProfile
+import heispirate.cattower.domain.post.model.Post
+import heispirate.cattower.infra.category.Category
+import heispirate.cattower.infra.category.CategoryInterface
 import org.springframework.stereotype.Service
 
 @Service
-class AdminServiceImpl : AdminService {
+class AdminServiceImpl(private val adminRepository: AdminRepository) : AdminService {
+    override fun checkAdmin(email: String, categorySelect: CategoryInterface): Boolean {
+        val admin = adminRepository.findByMainUserEmail(email) ?: throw IllegalArgumentException("이메일을 찾을수 없습니다")
+        return when(admin.role) {
+            Role.ADMIN -> true
+            Role.DAILY_LIFE_MANAGER -> categorySelect.category == Category.DAILY_LIFE
+            Role.INFORMATION_MANAGER -> categorySelect.category == Category.INFORMATION
+            Role.QUESTION_MANAGER -> categorySelect.category == Category.QUESTION
+            Role.SHARING_MANAGER -> categorySelect.category == Category.SHARING
+        }
+    }
+
+    // 예시 적용을 위한 펫 프로필 확인
+    private fun userCheck(post: Post,petProfile: PetProfile): Boolean {
+        return post.petProfile.id == petProfile.id
+    }
+
+    // 적용 예시
+    private fun checkAdminExample(email: String, post: Post, petProfile: PetProfile) {
+        if (checkAdmin(email,post)) {
+            // Post 삭제 로직
+        } else if (userCheck(post, petProfile)) {
+            // Post 삭제 로직
+        } else {
+            throw IllegalStateException("삭제할 권한이 없습니다.")
+        }
+    }
+
 }
+
+

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminServiceImpl.kt
@@ -5,19 +5,18 @@ import heispirate.cattower.domain.admin.repository.AdminRepository
 import heispirate.cattower.domain.petProfile.model.PetProfile
 import heispirate.cattower.domain.post.model.Post
 import heispirate.cattower.infra.category.Category
-import heispirate.cattower.infra.category.CategoryInterface
 import org.springframework.stereotype.Service
 
 @Service
 class AdminServiceImpl(private val adminRepository: AdminRepository) : AdminService {
-    override fun checkAdmin(email: String, categorySelect: CategoryInterface): Boolean {
+    override fun checkAdmin(email: String, categorySelect: Category): Boolean {
         val admin = adminRepository.findByMainUserEmail(email) ?: throw IllegalArgumentException("이메일을 찾을수 없습니다")
         return when(admin.role) {
             Role.ADMIN -> true
-            Role.DAILY_LIFE_MANAGER -> categorySelect.category == Category.DAILY_LIFE
-            Role.INFORMATION_MANAGER -> categorySelect.category == Category.INFORMATION
-            Role.QUESTION_MANAGER -> categorySelect.category == Category.QUESTION
-            Role.SHARING_MANAGER -> categorySelect.category == Category.SHARING
+            Role.DAILY_LIFE_MANAGER -> categorySelect == Category.DAILY_LIFE
+            Role.INFORMATION_MANAGER -> categorySelect == Category.INFORMATION
+            Role.QUESTION_MANAGER -> categorySelect == Category.QUESTION
+            Role.SHARING_MANAGER -> categorySelect == Category.SHARING
         }
     }
 
@@ -27,11 +26,13 @@ class AdminServiceImpl(private val adminRepository: AdminRepository) : AdminServ
     }
 
     // 적용 예시
-    private fun checkAdminExample(email: String, post: Post, petProfile: PetProfile) {
-        if (checkAdmin(email,post)) {
+    fun checkAdminTest(email: String, post: Post, petProfile: PetProfile) {
+        if (checkAdmin(email, post.category)) {
             // Post 삭제 로직
+            println("Post 삭제됨: ${post.id} by Admin")
         } else if (userCheck(post, petProfile)) {
             // Post 삭제 로직
+            println("Post 삭제됨: ${post.id} by User")
         } else {
             throw IllegalStateException("삭제할 권한이 없습니다.")
         }

--- a/src/main/kotlin/heispirate/cattower/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/comment/model/Comment.kt
@@ -3,8 +3,12 @@ package heispirate.cattower.domain.comment.model
 import heispirate.cattower.domain.petProfile.model.PetProfile
 import heispirate.cattower.domain.post.model.Post
 import heispirate.cattower.infra.BaseEntity
+import heispirate.cattower.infra.category.Category
+import heispirate.cattower.infra.category.CategoryInterface
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
@@ -30,9 +34,10 @@ class Comment(
     @JoinColumn(name = "petProfileId")
     val petProfile: PetProfile,
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "category")
-    val category : String,
+    override var category: Category
 
-) : BaseEntity() {
+) : BaseEntity(), CategoryInterface {
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/comment/model/Comment.kt
@@ -30,6 +30,9 @@ class Comment(
     @JoinColumn(name = "petProfileId")
     val petProfile: PetProfile,
 
+    @Column(name = "category")
+    val category : String,
+
 ) : BaseEntity() {
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/comment/model/SubComment.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/comment/model/SubComment.kt
@@ -2,8 +2,12 @@ package heispirate.cattower.domain.comment.model
 
 import heispirate.cattower.domain.petProfile.model.PetProfile
 import heispirate.cattower.infra.BaseEntity
+import heispirate.cattower.infra.category.Category
+import heispirate.cattower.infra.category.CategoryInterface
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
@@ -29,9 +33,10 @@ class SubComment(
     @JoinColumn(name = "petProfileId")
     val petProfile: PetProfile,
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "category")
-    val category : String,
+    override var category: Category
 
-    ) : BaseEntity() {
+) : BaseEntity(), CategoryInterface {
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/comment/model/SubComment.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/comment/model/SubComment.kt
@@ -29,6 +29,9 @@ class SubComment(
     @JoinColumn(name = "petProfileId")
     val petProfile: PetProfile,
 
+    @Column(name = "category")
+    val category : String,
+
     ) : BaseEntity() {
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/mainUser/repository/MainUserRepository.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/mainUser/repository/MainUserRepository.kt
@@ -4,4 +4,5 @@ import heispirate.cattower.domain.mainUser.model.MainUser
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MainUserRepository : JpaRepository<MainUser,Long> , CustomMainUserRepository {
+    fun findByEmail(email: String): MainUser?
 }

--- a/src/main/kotlin/heispirate/cattower/domain/post/model/Post.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/model/Post.kt
@@ -2,6 +2,8 @@ package heispirate.cattower.domain.post.model
 
 import heispirate.cattower.domain.petProfile.model.PetProfile
 import heispirate.cattower.infra.BaseEntity
+import heispirate.cattower.infra.category.Category
+import heispirate.cattower.infra.category.CategoryInterface
 import jakarta.persistence.CollectionTable
 import jakarta.persistence.Column
 import jakarta.persistence.ElementCollection
@@ -32,7 +34,7 @@ class Post(
 
     @Enumerated(EnumType.STRING)
     @Column(name = "category")
-    var category : Category,
+    override var category : Category,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "subCategory")
@@ -45,6 +47,6 @@ class Post(
     @JoinColumn(name = "petProfileId")
     val petProfile : PetProfile
 
-) : BaseEntity() {
+) : BaseEntity(), CategoryInterface {
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/post/model/SubCategory.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/model/SubCategory.kt
@@ -1,5 +1,7 @@
 package heispirate.cattower.domain.post.model
 
+import heispirate.cattower.infra.category.Category
+
 enum class SubCategory(val category: Category) {
     // DailyLife
     GOOD_THINGS(Category.DAILY_LIFE), // 좋은일

--- a/src/main/kotlin/heispirate/cattower/infra/category/Category.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/category/Category.kt
@@ -1,4 +1,4 @@
-package heispirate.cattower.domain.post.model
+package heispirate.cattower.infra.category
 
 enum class Category {
     DAILY_LIFE, // 일상

--- a/src/main/kotlin/heispirate/cattower/infra/category/CategoryInterface.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/category/CategoryInterface.kt
@@ -1,0 +1,5 @@
+package heispirate.cattower.infra.category
+
+interface CategoryInterface {
+    val category: Category
+}

--- a/src/test/kotlin/heispirate/cattower/adminTest/AdminRoleTest.kt
+++ b/src/test/kotlin/heispirate/cattower/adminTest/AdminRoleTest.kt
@@ -33,7 +33,7 @@ class AdminRoleTest @Autowired constructor(
     private val petProfileRepository: PetProfileRepository,
 ) {
 
-    private val adminService = AdminServiceImpl(adminRepository)
+    private val adminService = AdminServiceImpl(adminRepository,mainUserRepository)
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/heispirate/cattower/adminTest/AdminRoleTest.kt
+++ b/src/test/kotlin/heispirate/cattower/adminTest/AdminRoleTest.kt
@@ -1,0 +1,181 @@
+package heispirate.cattower.adminTest
+
+import heispirate.cattower.domain.admin.model.Admin
+import heispirate.cattower.domain.admin.model.Role
+import heispirate.cattower.domain.admin.repository.AdminRepository
+import heispirate.cattower.domain.admin.service.AdminServiceImpl
+import heispirate.cattower.domain.mainUser.model.MainUser
+import heispirate.cattower.domain.mainUser.repository.MainUserRepository
+import heispirate.cattower.domain.petProfile.model.Gender
+import heispirate.cattower.domain.petProfile.model.PetProfile
+import heispirate.cattower.domain.petProfile.repository.PetProfileRepository
+import heispirate.cattower.domain.post.model.Post
+import heispirate.cattower.domain.post.model.SubCategory
+import heispirate.cattower.domain.post.repository.PostRepository
+import heispirate.cattower.infra.category.Category
+import java.time.LocalDateTime
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test1")
+class AdminRoleTest @Autowired constructor(
+    private val adminRepository: AdminRepository,
+    private val postRepository: PostRepository,
+    private val mainUserRepository: MainUserRepository,
+    private val petProfileRepository: PetProfileRepository,
+) {
+
+    private val adminService = AdminServiceImpl(adminRepository)
+
+    @BeforeEach
+    fun setUp() {
+        val mainUser1 = MainUser(
+            todayExperience = 0,
+            experience = 10,
+            level = 1,
+            aboutMe = null,
+            email = "user1@gmail.com",
+            nickname = "user1",
+            password = "1234",
+            phoneNumber = "12345",
+            providerId = "kakao",
+            provider = "ka"
+        )
+        val savedMainUser1 = mainUserRepository.saveAndFlush(mainUser1)
+
+        val petProfile1 = PetProfile(
+            aboutMe = "test",
+            address = null,
+            age = 1,
+            birthDay = LocalDateTime.now(),
+            bloodType = null,
+            disclosure = true,
+            gender = Gender.MALE,
+            healthHistory = "test",
+            kind = null,
+            mainUser = savedMainUser1,
+            name = "pet1",
+            profileImageUrl = "test",
+            weight = 1.0
+        )
+        val savedPetProfile1 = petProfileRepository.saveAndFlush(petProfile1)
+
+        val post1 = Post(
+            title = "test1",
+            category = Category.DAILY_LIFE,
+            content = "test1",
+            imageUrl = null,
+            likeCounts = 0,
+            petProfile = savedPetProfile1,
+            subCategory = SubCategory.GOOD_THINGS,
+            writer = petProfile1.name
+        )
+        postRepository.saveAndFlush(post1)
+
+        val mainUser2 = MainUser(
+            todayExperience = 0,
+            experience = 10,
+            level = 1,
+            aboutMe = null,
+            email = "user2@gmail.com",
+            nickname = "zzzz",
+            password = "1234",
+            phoneNumber = "12345",
+            providerId = "kakao",
+            provider = "ka"
+        )
+        val savedMainUser2 = mainUserRepository.saveAndFlush(mainUser2)
+
+        val petProfile2 = PetProfile(
+            aboutMe = "test",
+            address = null,
+            age = 1,
+            birthDay = LocalDateTime.now(),
+            bloodType = null,
+            disclosure = true,
+            gender = Gender.MALE,
+            healthHistory = "test",
+            kind = null,
+            mainUser = savedMainUser2,
+            name = "pet2",
+            profileImageUrl = "test",
+            weight = 1.0
+        )
+        val savedPetProfile2 = petProfileRepository.saveAndFlush(petProfile2)
+
+        val post2 = Post(
+            title = "test2",
+            category = Category.INFORMATION,
+            content = "test2",
+            imageUrl = null,
+            likeCounts = 0,
+            petProfile = savedPetProfile2,
+            subCategory = SubCategory.GOOD_THINGS,
+            writer = petProfile2.name
+        )
+        postRepository.saveAndFlush(post2)
+
+        val dailyLifeManager = Admin(
+            mainUser = savedMainUser1,
+            role = Role.DAILY_LIFE_MANAGER
+        )
+        adminRepository.saveAndFlush(dailyLifeManager)
+
+        val admin = Admin(
+            mainUser = savedMainUser2,
+            role = Role.ADMIN
+        )
+        adminRepository.saveAndFlush(admin)
+    }
+
+    @Test
+    fun `일상 카테고리 관리자일 경우 다른 사용자의 정보 게시물을 삭제할 시 Exception이 정상 작동하는지 테스트`() {
+        // given
+        val email = "user1@gmail.com"
+        val post = postRepository.findAll().last()
+        val petProfile = petProfileRepository.findAll().first()
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            adminService.checkAdminTest(email, post, petProfile)
+        }
+    }
+
+    @Test
+    fun `일상 카테고리 관리자일 경우 다른 사용자의 일상 게시물을 삭제할 수 있는지 테스트`() {
+        // given
+        val email = "user1@gmail.com"
+        val post = postRepository.findAll().first()
+        val petProfile = petProfileRepository.findAll().first()
+
+        // when
+        adminService.checkAdminTest(email, post, petProfile)
+
+        // then
+        val deletedPost = postRepository.findById(post.id!!)
+        assertTrue(deletedPost.isPresent)
+    }
+
+    @Test
+    fun `Role이 Admin일 경우 모든 게시물을 삭제할 수 있는지 테스트`() {
+        // given
+        val email = "user2@gmail.com"
+        val post = postRepository.findAll().first()
+        val petProfile = petProfileRepository.findAll().first()
+
+        // when
+        adminService.checkAdminTest(email, post, petProfile)
+
+        // then
+        val deletedPost = postRepository.findById(post.id!!)
+        assertTrue(deletedPost.isPresent)
+    }
+}

--- a/src/test/kotlin/heispirate/cattower/adminTest/ChangeAdminTest.kt
+++ b/src/test/kotlin/heispirate/cattower/adminTest/ChangeAdminTest.kt
@@ -1,0 +1,97 @@
+package heispirate.cattower.adminTest
+
+import heispirate.cattower.domain.admin.dto.AdminRequestDTOver1
+import heispirate.cattower.domain.admin.model.Admin
+import heispirate.cattower.domain.admin.model.Role
+import heispirate.cattower.domain.admin.repository.AdminRepository
+import heispirate.cattower.domain.admin.service.AdminServiceImpl
+import heispirate.cattower.domain.mainUser.model.MainUser
+import heispirate.cattower.domain.mainUser.repository.MainUserRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test1")
+class ChangeAdminTest @Autowired constructor(
+    private val adminRepository: AdminRepository,
+    private val mainUserRepository: MainUserRepository,
+) {
+
+    private val adminService = AdminServiceImpl(adminRepository, mainUserRepository)
+
+    @Test
+    fun `어드민이 아닐 경우 예외를 정상적으로 throw 하는지 테스트`() {
+        // given
+        val mainUser1 = MainUser(
+            todayExperience = 0,
+            experience = 10,
+            level = 1,
+            aboutMe = null,
+            email = "user1@gmail.com",
+            nickname = "user1",
+            password = "1234",
+            phoneNumber = "12345",
+            providerId = "kakao",
+            provider = "ka"
+        )
+        mainUserRepository.saveAndFlush(mainUser1)
+
+        val admin = Admin(role = Role.SHARING_MANAGER, mainUser = mainUser1)
+        adminRepository.saveAndFlush(admin)
+
+        val request = AdminRequestDTOver1(role = Role.INFORMATION_MANAGER, userEmail = mainUser1.email, adminEmail = mainUser1.email)
+
+        // when & then
+        assertThrows<IllegalStateException> {
+            adminService.changeUserToAdminVersion1(request)
+        }
+    }
+
+    @Test
+    fun `어드민일 경우 원하는 MainUser를 INFORMATION_MANAGER 로 생성하여 저장 할 수 있는지 테스트`() {
+        // given
+        val newAdminUser = MainUser(
+            todayExperience = 0,
+            experience = 10,
+            level = 1,
+            aboutMe = null,
+            email = "newInfoAdmin@gmail.com",
+            nickname = "user1",
+            password = "1234",
+            phoneNumber = "12345",
+            providerId = "kakao",
+            provider = "ka"
+        )
+        val adminUser = MainUser(
+            todayExperience = 0,
+            experience = 10,
+            level = 1,
+            aboutMe = null,
+            email = "admin@gmail.com",
+            nickname = "user1",
+            password = "1234",
+            phoneNumber = "12345",
+            providerId = "kakao",
+            provider = "ka"
+        )
+        mainUserRepository.saveAllAndFlush(listOf(adminUser,newAdminUser))
+
+        val admin = Admin(role = Role.ADMIN, mainUser = adminUser)
+        adminRepository.saveAndFlush(admin)
+
+        val request = AdminRequestDTOver1(role = Role.INFORMATION_MANAGER, userEmail = newAdminUser.email, adminEmail = adminUser.email)
+
+        // when
+        adminService.changeUserToAdminVersion1(request)
+
+        // then
+        val updatedAdmin = adminRepository.findByMainUserEmail(newAdminUser.email)
+        assertEquals(Role.INFORMATION_MANAGER, updatedAdmin?.role)
+    }
+}


### PR DESCRIPTION
## 이슈번호
#10 

## 작업 내용
- 관리자 기능을 위해 comment와 subComment에 category컬럼 추가
- 관리자 검증 기능 추가
- post 삭제시 시나리오를 통한 테스트 코드 작성
- 일반유저를 관리자로 변경하는 기능 추가 및 테스트 코드 작성

## 설명 해주세요
- if조건문에서 사용할 경우를 생각해서 true를 반환하게함
- ADMIN 은 항상 true기 때문에 조건을 항상 통과
- 그 외 다른 게시판 관리자들은 각자의 게시판에 맞는 카테고리를 가진 글/댓글/대댓글 일 경우에만 true
- 관리자 변경은 ADMIN의 Role을 가진 사람만 가능함

## 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트를 했나요(코드/ 물리)?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 주석을 지웠나요?
