### PR TITLE
펫 프로필 기능 추가

### DIFF
--- a/src/main/kotlin/heispirate/cattower/domain/mainUser/model/MainUser.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/mainUser/model/MainUser.kt
@@ -1,8 +1,12 @@
 package heispirate.cattower.domain.mainUser.model
 
+import heispirate.cattower.domain.petProfile.model.PetProfile
 import heispirate.cattower.infra.BaseEntity
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 
 @Table(name = "mainUser")
@@ -37,6 +41,9 @@ class MainUser(
 
     @Column(name = "providerId")
     val providerId: String?,
+
+    @OneToMany(mappedBy = "mainUser", cascade = [CascadeType.ALL], orphanRemoval=true, fetch = FetchType.LAZY)
+    var petProfiles: MutableList<PetProfile>? = mutableListOf()
 
     ) : BaseEntity() {
 

--- a/src/main/kotlin/heispirate/cattower/domain/mainUser/repository/MainUserRepository.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/mainUser/repository/MainUserRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface MainUserRepository : JpaRepository<MainUser,Long> , CustomMainUserRepository {
     fun findByEmail(email: String): MainUser?
+
+    fun findByIdAndDeletedAtIsNull(userId: Long): MainUser?
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
@@ -25,7 +25,7 @@ class PetProfileController(
         @RequestBody createPetProfileRequestDTO: PetProfileRequestDTO
     ): ResponseEntity<PetProfileResponseDTO> {
         return ResponseEntity
-            .status(HttpStatus.OK)
+            .status(HttpStatus.CREATED)
             .body(petProfileService.createPetProfile(userId, createPetProfileRequestDTO))
     }
     @GetMapping("/{petId}")

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
@@ -5,6 +5,7 @@ import heispirate.cattower.domain.petProfile.dto.PetProfileResponseDTO
 import heispirate.cattower.domain.petProfile.service.PetProfileService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -54,6 +55,14 @@ class PetProfileController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(petProfileService.updatePetProfile(userId, petId, petProfileRequestDTO))
+    }
+
+    @DeleteMapping("/{petId}")
+    fun deletePetProfile(
+        @PathVariable userId: Long,
+        @PathVariable petId: Long
+    ): ResponseEntity<Unit> {
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(petProfileService.deletePetProfile(userId, petId))
     }
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
@@ -1,7 +1,30 @@
 package heispirate.cattower.domain.petProfile.controller
 
+import heispirate.cattower.domain.petProfile.dto.CreatePetProfileRequestDTO
+import heispirate.cattower.domain.petProfile.dto.PetProfileResponseDTO
+import heispirate.cattower.domain.petProfile.service.PetProfileService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class PetProfileController {
+@RequestMapping("/users/{userId}/pets")
+class PetProfileController(
+    private val petProfileService: PetProfileService
+) {
+    @PostMapping()
+    fun createPetProfile(
+        @PathVariable userId: Long,
+        @RequestBody createPetProfileRequestDTO: CreatePetProfileRequestDTO
+    ): ResponseEntity<PetProfileResponseDTO> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(petProfileService.createPetProfile(userId, createPetProfileRequestDTO))
+    }
+
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
@@ -1,6 +1,6 @@
 package heispirate.cattower.domain.petProfile.controller
 
-import heispirate.cattower.domain.petProfile.dto.CreatePetProfileRequestDTO
+import heispirate.cattower.domain.petProfile.dto.PetProfileRequestDTO
 import heispirate.cattower.domain.petProfile.dto.PetProfileResponseDTO
 import heispirate.cattower.domain.petProfile.service.PetProfileService
 import org.springframework.http.HttpStatus
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -20,20 +21,39 @@ class PetProfileController(
     @PostMapping()
     fun createPetProfile(
         @PathVariable userId: Long,
-        @RequestBody createPetProfileRequestDTO: CreatePetProfileRequestDTO
+        @RequestBody createPetProfileRequestDTO: PetProfileRequestDTO
     ): ResponseEntity<PetProfileResponseDTO> {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(petProfileService.createPetProfile(userId, createPetProfileRequestDTO))
     }
-    @GetMapping("{petId}")
+    @GetMapping("/{petId}")
     fun getPetProfile(
+        @PathVariable userId: Long,
         @PathVariable petId: Long
     ): ResponseEntity<PetProfileResponseDTO> {
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(petProfileService.getPetProfile(petId))
+            .body(petProfileService.getPetProfile(userId, petId))
+    }
+    @GetMapping()
+    fun getUsersPetProfileList(
+        @PathVariable userId: Long
+    ): ResponseEntity<List<PetProfileResponseDTO>> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(petProfileService.getUsersPetProfileList(userId))
     }
 
+    @PutMapping("/{petId}")
+    fun updatePetProfile(
+        @PathVariable userId: Long,
+        @PathVariable petId: Long,
+        @RequestBody petProfileRequestDTO: PetProfileRequestDTO
+    ): ResponseEntity<PetProfileResponseDTO> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(petProfileService.updatePetProfile(userId, petId, petProfileRequestDTO))
+    }
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
@@ -3,6 +3,7 @@ package heispirate.cattower.domain.petProfile.controller
 import heispirate.cattower.domain.petProfile.dto.PetProfileRequestDTO
 import heispirate.cattower.domain.petProfile.dto.PetProfileResponseDTO
 import heispirate.cattower.domain.petProfile.service.PetProfileService
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -19,6 +20,8 @@ import org.springframework.web.bind.annotation.RestController
 class PetProfileController(
     private val petProfileService: PetProfileService
 ) {
+
+    @Operation(summary = "펫 프로필 생성", description = "사용자가 새로운 펫 프로필을 생성합니다.")
     @PostMapping()
     fun createPetProfile(
         @PathVariable userId: Long,
@@ -28,6 +31,7 @@ class PetProfileController(
             .status(HttpStatus.CREATED)
             .body(petProfileService.createPetProfile(userId, createPetProfileRequestDTO))
     }
+    @Operation(summary = "펫 프로필 조회", description = "특정 펫 프로필을 조회합니다.")
     @GetMapping("/{petId}")
     fun getPetProfile(
         @PathVariable userId: Long,
@@ -37,6 +41,8 @@ class PetProfileController(
             .status(HttpStatus.OK)
             .body(petProfileService.getPetProfile(userId, petId))
     }
+
+    @Operation(summary = "펫 프로필 목록 조회", description = "특정 사용자의 펫 프로필 목록을 조회합니다.")
     @GetMapping()
     fun getUsersPetProfileList(
         @PathVariable userId: Long
@@ -46,6 +52,7 @@ class PetProfileController(
             .body(petProfileService.getUsersPetProfileList(userId))
     }
 
+    @Operation(summary = "펫 프로필 수정", description = "특정 펫 프로필을 수정합니다.")
     @PutMapping("/{petId}")
     fun updatePetProfile(
         @PathVariable userId: Long,
@@ -57,6 +64,7 @@ class PetProfileController(
             .body(petProfileService.updatePetProfile(userId, petId, petProfileRequestDTO))
     }
 
+    @Operation(summary = "펫 프로필 삭제", description = "특정 펫 프로필을 삭제합니다.")
     @DeleteMapping("/{petId}")
     fun deletePetProfile(
         @PathVariable userId: Long,

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/controller/PetProfileController.kt
@@ -5,6 +5,7 @@ import heispirate.cattower.domain.petProfile.dto.PetProfileResponseDTO
 import heispirate.cattower.domain.petProfile.service.PetProfileService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -24,6 +25,14 @@ class PetProfileController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(petProfileService.createPetProfile(userId, createPetProfileRequestDTO))
+    }
+    @GetMapping("{petId}")
+    fun getPetProfile(
+        @PathVariable petId: Long
+    ): ResponseEntity<PetProfileResponseDTO> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(petProfileService.getPetProfile(petId))
     }
 
 

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/CreatePetProfileRequestDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/CreatePetProfileRequestDTO.kt
@@ -1,0 +1,37 @@
+package heispirate.cattower.domain.petProfile.dto
+
+import heispirate.cattower.domain.petProfile.model.Gender
+import heispirate.cattower.domain.petProfile.model.PetProfile
+import java.time.LocalDateTime
+
+data class CreatePetProfileRequestDTO(
+    val name: String,
+    val gender: Gender,
+    val birthDay: LocalDateTime,
+    val age: Int,
+    val kind: String?,
+    val address: String?,
+    val aboutMe: String?,
+    val bloodType: String?,
+    val weight: Double?,
+    val healthHistory: String?,
+    val profileImageUrl: String?,
+    val disclosure: Boolean,
+) {
+    fun toEntity(): PetProfile {
+            return PetProfile(
+                name = name,
+                gender = gender,
+                birthDay = birthDay,
+                age = age,
+                kind = kind,
+                address = address,
+                aboutMe = aboutMe,
+                bloodType = bloodType,
+                weight = weight,
+                healthHistory = healthHistory,
+                profileImageUrl = profileImageUrl,
+                disclosure = disclosure,
+            )
+    }
+}

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/CreatePetProfileRequestDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/CreatePetProfileRequestDTO.kt
@@ -15,7 +15,7 @@ data class CreatePetProfileRequestDTO(
     val bloodType: String?,
     val weight: Double?,
     val healthHistory: String?,
-    val profileImageUrl: String?,
+    val profileImageUrl: String,
     val disclosure: Boolean,
 ) {
     fun toEntity(): PetProfile {

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/PetProfileRequestDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/PetProfileRequestDTO.kt
@@ -1,5 +1,6 @@
 package heispirate.cattower.domain.petProfile.dto
 
+import heispirate.cattower.domain.mainUser.model.MainUser
 import heispirate.cattower.domain.petProfile.model.Gender
 import heispirate.cattower.domain.petProfile.model.PetProfile
 import java.time.LocalDateTime
@@ -18,7 +19,7 @@ data class PetProfileRequestDTO(
     val profileImageUrl: String,
     val disclosure: Boolean,
 ) {
-    fun toEntity(): PetProfile {
+    fun toEntity(mainUser: MainUser): PetProfile {
             return PetProfile(
                 name = name,
                 gender = gender,
@@ -32,6 +33,7 @@ data class PetProfileRequestDTO(
                 healthHistory = healthHistory,
                 profileImageUrl = profileImageUrl,
                 disclosure = disclosure,
+                mainUser = mainUser
             )
     }
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/PetProfileRequestDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/PetProfileRequestDTO.kt
@@ -1,6 +1,0 @@
-package heispirate.cattower.domain.petProfile.dto
-
-//data class PetProfileRequestDTO(
-//    val
-//    //TODO 나중에 필요한 것 채워넣기
-//)

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/PetProfileRequestDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/PetProfileRequestDTO.kt
@@ -4,7 +4,7 @@ import heispirate.cattower.domain.petProfile.model.Gender
 import heispirate.cattower.domain.petProfile.model.PetProfile
 import java.time.LocalDateTime
 
-data class CreatePetProfileRequestDTO(
+data class PetProfileRequestDTO(
     val name: String,
     val gender: Gender,
     val birthDay: LocalDateTime,

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/PetProfileResponseDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/dto/PetProfileResponseDTO.kt
@@ -1,0 +1,39 @@
+package heispirate.cattower.domain.petProfile.dto
+
+import heispirate.cattower.domain.petProfile.model.Gender
+import heispirate.cattower.domain.petProfile.model.PetProfile
+import java.time.LocalDateTime
+data class PetProfileResponseDTO(
+    val name: String,
+    val gender: Gender,
+    val birthday: LocalDateTime,
+    val age: Int,
+    val kind: String?,
+    val address: String?,
+    val aboutMe: String?,
+    val bloodType: String?,
+    val weight: Double?,
+    val healthHistory: String?,
+    val profileImageUrl: String?,
+    val disclosure: Boolean
+) {
+
+    companion object {
+        fun toResponse(petProfile: PetProfile): PetProfileResponseDTO {
+            return PetProfileResponseDTO(
+                name = petProfile.name,
+                gender = petProfile.gender,
+                birthday = petProfile.birthDay,
+                age = petProfile.age,
+                kind = petProfile.kind,
+                address = petProfile.address,
+                aboutMe = petProfile.aboutMe,
+                bloodType = petProfile.bloodType,
+                weight = petProfile.weight,
+                healthHistory = petProfile.healthHistory,
+                profileImageUrl = petProfile.profileImageUrl,
+                disclosure = petProfile.disclosure,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/model/PetProfile.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/model/PetProfile.kt
@@ -16,45 +16,45 @@ import java.time.LocalDateTime
 @Entity
 class PetProfile(
     @Column(name = "name")
-    val name : String,
+    val name: String,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "gender")
     var gender: Gender,
 
     @Column(name = "birthDay")
-    val birthDay : LocalDateTime,
+    val birthDay: LocalDateTime,
 
     @Column(name = "age")
-    var age : Int,
+    var age: Int,
 
     @Column(name = "kind")
-    val kind : String?,
+    val kind: String?,
 
     @Column(name = "address")
-    var address : String?,
+    var address: String?,
 
     @Column(name = "aboutMe")
-    var aboutMe: String,
+    var aboutMe: String?,
 
     @Column(name = "bloodType")
-    val bloodType : String?,
+    val bloodType: String?,
 
     @Column(name = "weight")
-    var weight : Double?,
+    var weight: Double?,
 
     @Column(name = "healthHistory")
-    var healthHistory : String?,
+    var healthHistory: String?,
 
     @Column(name = "profileImageUrl")
-    var profileImageUrl : String,
+    var profileImageUrl: String,
 
     @Column(name = "disclosure")
-    var disclosure : Boolean,
+    var disclosure: Boolean,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "mainUserId")
-    val mainUser: MainUser,
+    @JoinColumn(name = "main_user_id")
+    var mainUser: MainUser? = null
 
     ) : BaseEntity() {
 

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/model/PetProfile.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/model/PetProfile.kt
@@ -54,7 +54,7 @@ class PetProfile(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "main_user_id")
-    var mainUser: MainUser? = null
+    var mainUser: MainUser
 
     ) : BaseEntity() {
 

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/model/PetProfile.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/model/PetProfile.kt
@@ -16,20 +16,20 @@ import java.time.LocalDateTime
 @Entity
 class PetProfile(
     @Column(name = "name")
-    val name: String,
+    var name: String,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "gender")
     var gender: Gender,
 
     @Column(name = "birthDay")
-    val birthDay: LocalDateTime,
+    var birthDay: LocalDateTime,
 
     @Column(name = "age")
     var age: Int,
 
     @Column(name = "kind")
-    val kind: String?,
+    var kind: String?,
 
     @Column(name = "address")
     var address: String?,
@@ -38,7 +38,7 @@ class PetProfile(
     var aboutMe: String?,
 
     @Column(name = "bloodType")
-    val bloodType: String?,
+    var bloodType: String?,
 
     @Column(name = "weight")
     var weight: Double?,

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/repository/PetProfileRepository.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/repository/PetProfileRepository.kt
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface PetProfileRepository : JpaRepository<PetProfile,Long> , CustomPetProfileRepository {
 
     fun findAllByMainUser(mainUser: MainUser): List<PetProfile>
+
+    fun findByIdAndDeletedAtIsNull(petId: Long): PetProfile?
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/repository/PetProfileRepository.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/repository/PetProfileRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface PetProfileRepository : JpaRepository<PetProfile,Long> , CustomPetProfileRepository {
 
-    fun findAllByMainUser(mainUser: MainUser): List<PetProfile>
+    fun findAllByMainUserAndDeletedAtIsNull(mainUser: MainUser): List<PetProfile>
 
     fun findByIdAndDeletedAtIsNull(petId: Long): PetProfile?
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/repository/PetProfileRepository.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/repository/PetProfileRepository.kt
@@ -1,7 +1,10 @@
 package heispirate.cattower.domain.petProfile.repository
 
+import heispirate.cattower.domain.mainUser.model.MainUser
 import heispirate.cattower.domain.petProfile.model.PetProfile
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface PetProfileRepository : JpaRepository<PetProfile,Long> , CustomPetProfileRepository {
+
+    fun findAllByMainUser(mainUser: MainUser): List<PetProfile>
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
@@ -6,4 +6,6 @@ import heispirate.cattower.domain.petProfile.dto.PetProfileResponseDTO
 interface PetProfileService {
     fun createPetProfile(userId: Long, createPetProfileRequestDTO: CreatePetProfileRequestDTO
     ): PetProfileResponseDTO
+
+    fun getPetProfile(petId: Long): PetProfileResponseDTO
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
@@ -11,4 +11,6 @@ interface PetProfileService {
 
     fun getUsersPetProfileList(userId: Long): List<PetProfileResponseDTO>
 
+    fun updatePetProfile(userId: Long, petId: Long, petProfileRequestDTO: PetProfileRequestDTO): PetProfileResponseDTO
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
@@ -1,4 +1,9 @@
 package heispirate.cattower.domain.petProfile.service
 
+import heispirate.cattower.domain.petProfile.dto.CreatePetProfileRequestDTO
+import heispirate.cattower.domain.petProfile.dto.PetProfileResponseDTO
+
 interface PetProfileService {
+    fun createPetProfile(userId: Long, createPetProfileRequestDTO: CreatePetProfileRequestDTO
+    ): PetProfileResponseDTO
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
@@ -1,11 +1,13 @@
 package heispirate.cattower.domain.petProfile.service
 
-import heispirate.cattower.domain.petProfile.dto.CreatePetProfileRequestDTO
+import heispirate.cattower.domain.petProfile.dto.PetProfileRequestDTO
 import heispirate.cattower.domain.petProfile.dto.PetProfileResponseDTO
 
 interface PetProfileService {
-    fun createPetProfile(userId: Long, createPetProfileRequestDTO: CreatePetProfileRequestDTO
+    fun createPetProfile(userId: Long, petProfileRequestDTO: PetProfileRequestDTO
     ): PetProfileResponseDTO
 
-    fun getPetProfile(petId: Long): PetProfileResponseDTO
+    fun getPetProfile(userId: Long, petId: Long): PetProfileResponseDTO
+
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
@@ -13,4 +13,6 @@ interface PetProfileService {
 
     fun updatePetProfile(userId: Long, petId: Long, petProfileRequestDTO: PetProfileRequestDTO): PetProfileResponseDTO
 
+    fun deletePetProfile(userId: Long, petId: Long)
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileService.kt
@@ -9,5 +9,6 @@ interface PetProfileService {
 
     fun getPetProfile(userId: Long, petId: Long): PetProfileResponseDTO
 
+    fun getUsersPetProfileList(userId: Long): List<PetProfileResponseDTO>
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
@@ -1,7 +1,7 @@
 package heispirate.cattower.domain.petProfile.service
 
 import heispirate.cattower.domain.mainUser.repository.MainUserRepository
-import heispirate.cattower.domain.petProfile.dto.CreatePetProfileRequestDTO
+import heispirate.cattower.domain.petProfile.dto.PetProfileRequestDTO
 import heispirate.cattower.domain.petProfile.dto.PetProfileResponseDTO
 import heispirate.cattower.domain.petProfile.repository.PetProfileRepository
 import heispirate.cattower.exception.ModelNotFoundException
@@ -17,20 +17,30 @@ class PetProfileServiceImpl(
     @Transactional
     override fun createPetProfile(
         userId: Long,
-        createPetProfileRequestDTO: CreatePetProfileRequestDTO
+        petProfileRequestDTO: PetProfileRequestDTO
     ): PetProfileResponseDTO {
         val mainUser = mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
         val petProfiles = petProfileRepository.findAllByMainUser(mainUser)
         if (petProfiles.isNotEmpty() && petProfiles.size >= 3) {
             throw Exception("펫 프로필 생성은 3개를 초과할 수 없습니다.")
         }
-        val newPetProfile = createPetProfileRequestDTO.toEntity().apply { this.mainUser = mainUser }
-        mainUser.petProfiles?.add(newPetProfile)
+        val newPetProfile = petProfileRequestDTO.toEntity().apply { this.mainUser = mainUser }
         val savedPetProfile = petProfileRepository.save(newPetProfile)
+        mainUser.petProfiles?.add(newPetProfile)
         return PetProfileResponseDTO.toResponse(savedPetProfile)
     }
-    override fun getPetProfile(petId: Long): PetProfileResponseDTO {
+    override fun getPetProfile(
+        userId: Long,
+        petId: Long
+    ): PetProfileResponseDTO {
+        mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
         val petProfile = petProfileRepository.findByIdOrNull(petId) ?: throw ModelNotFoundException("pet", petId)
         return PetProfileResponseDTO.toResponse(petProfile)
+    }
+
+    override fun getUsersPetProfileList(userId: Long): List<PetProfileResponseDTO> {
+        val mainUser = mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
+        val petProfiles = petProfileRepository.findAllByMainUser(mainUser)
+        return petProfiles.map { PetProfileResponseDTO.toResponse(it) }
     }
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
@@ -29,4 +29,8 @@ class PetProfileServiceImpl(
         val savedPetProfile = petProfileRepository.save(newPetProfile)
         return PetProfileResponseDTO.toResponse(savedPetProfile)
     }
+    override fun getPetProfile(petId: Long): PetProfileResponseDTO {
+        val petProfile = petProfileRepository.findByIdOrNull(petId) ?: throw ModelNotFoundException("pet", petId)
+        return PetProfileResponseDTO.toResponse(petProfile)
+    }
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
@@ -43,4 +43,29 @@ class PetProfileServiceImpl(
         val petProfiles = petProfileRepository.findAllByMainUser(mainUser)
         return petProfiles.map { PetProfileResponseDTO.toResponse(it) }
     }
+
+    @Transactional
+    override fun updatePetProfile(userId: Long, petId: Long, petProfileRequestDTO: PetProfileRequestDTO
+    ): PetProfileResponseDTO {
+        val mainUser = mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
+        val petProfile = petProfileRepository.findByIdOrNull(petId) ?: throw ModelNotFoundException("pet", petId)
+
+        if (petProfile.mainUser != mainUser) {
+            throw Exception("해당 유저의 펫프로필이 아닙니다.")
+        }
+        petProfile.apply { name = petProfileRequestDTO.name
+            gender = petProfileRequestDTO.gender
+            birthDay = petProfileRequestDTO.birthDay
+            age = petProfileRequestDTO.age
+            kind = petProfileRequestDTO.kind
+            address = petProfileRequestDTO.address
+            aboutMe = petProfileRequestDTO.aboutMe
+            bloodType = petProfileRequestDTO.bloodType
+            weight = petProfileRequestDTO.weight
+            healthHistory = petProfileRequestDTO.healthHistory
+            profileImageUrl = petProfileRequestDTO.profileImageUrl
+            disclosure = petProfileRequestDTO.disclosure}
+        val updatedPetProfile = petProfileRepository.save(petProfile)
+        return PetProfileResponseDTO.toResponse(updatedPetProfile)
+    }
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
@@ -33,8 +33,12 @@ class PetProfileServiceImpl(
         userId: Long,
         petId: Long
     ): PetProfileResponseDTO {
-        mainUserRepository.findByIdAndDeletedAtIsNull(userId) ?: throw ModelNotFoundException("user", userId)
-        val petProfile = petProfileRepository.findByIdAndDeletedAtIsNull(petId) ?: throw ModelNotFoundException("pet", petId)
+        val petProfile =
+            petProfileRepository.findByIdAndDeletedAtIsNull(petId) ?: throw ModelNotFoundException("pet", petId)
+        val mainUser = mainUserRepository.findByIdAndDeletedAtIsNull(userId) ?: throw ModelNotFoundException("user", userId)
+        if (!petProfile.disclosure && petProfile.mainUser?.id != mainUser.id) {
+                throw Exception("비공개 프로필입니다.")
+            }
         return PetProfileResponseDTO.toResponse(petProfile)
     }
 

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
@@ -21,12 +21,12 @@ class PetProfileServiceImpl(
     ): PetProfileResponseDTO {
         val mainUser = mainUserRepository.findByIdAndDeletedAtIsNull(userId) ?: throw ModelNotFoundException("user", userId)
         val petProfiles = petProfileRepository.findAllByMainUserAndDeletedAtIsNull(mainUser)
-        if (petProfiles.isNotEmpty() && petProfiles.size >= 3) {
+        if (petProfiles.size >= 3) {
             throw Exception("펫 프로필 생성은 3개를 초과할 수 없습니다.")
         }
-        val newPetProfile = petProfileRequestDTO.toEntity().apply { this.mainUser = mainUser }
+        val newPetProfile = petProfileRequestDTO.toEntity(mainUser) // .apply { this.mainUser = mainUser }
         val savedPetProfile = petProfileRepository.save(newPetProfile)
-        mainUser.petProfiles?.add(newPetProfile)
+        // mainUser.petProfiles?.add(newPetProfile)
         return PetProfileResponseDTO.toResponse(savedPetProfile)
     }
     override fun getPetProfile(

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
@@ -5,7 +5,6 @@ import heispirate.cattower.domain.petProfile.dto.PetProfileRequestDTO
 import heispirate.cattower.domain.petProfile.dto.PetProfileResponseDTO
 import heispirate.cattower.domain.petProfile.repository.PetProfileRepository
 import heispirate.cattower.exception.ModelNotFoundException
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -20,8 +19,8 @@ class PetProfileServiceImpl(
         userId: Long,
         petProfileRequestDTO: PetProfileRequestDTO
     ): PetProfileResponseDTO {
-        val mainUser = mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
-        val petProfiles = petProfileRepository.findAllByMainUser(mainUser)
+        val mainUser = mainUserRepository.findByIdAndDeletedAtIsNull(userId) ?: throw ModelNotFoundException("user", userId)
+        val petProfiles = petProfileRepository.findAllByMainUserAndDeletedAtIsNull(mainUser)
         if (petProfiles.isNotEmpty() && petProfiles.size >= 3) {
             throw Exception("펫 프로필 생성은 3개를 초과할 수 없습니다.")
         }
@@ -34,22 +33,22 @@ class PetProfileServiceImpl(
         userId: Long,
         petId: Long
     ): PetProfileResponseDTO {
-        mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
-        val petProfile = petProfileRepository.findByIdOrNull(petId) ?: throw ModelNotFoundException("pet", petId)
+        mainUserRepository.findByIdAndDeletedAtIsNull(userId) ?: throw ModelNotFoundException("user", userId)
+        val petProfile = petProfileRepository.findByIdAndDeletedAtIsNull(petId) ?: throw ModelNotFoundException("pet", petId)
         return PetProfileResponseDTO.toResponse(petProfile)
     }
 
     override fun getUsersPetProfileList(userId: Long): List<PetProfileResponseDTO> {
-        val mainUser = mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
-        val petProfiles = petProfileRepository.findAllByMainUser(mainUser)
+        val mainUser = mainUserRepository.findByIdAndDeletedAtIsNull(userId) ?: throw ModelNotFoundException("user", userId)
+        val petProfiles = petProfileRepository.findAllByMainUserAndDeletedAtIsNull(mainUser)
         return petProfiles.map { PetProfileResponseDTO.toResponse(it) }
     }
 
     @Transactional
     override fun updatePetProfile(userId: Long, petId: Long, petProfileRequestDTO: PetProfileRequestDTO
     ): PetProfileResponseDTO {
-        val mainUser = mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
-        val petProfile = petProfileRepository.findByIdOrNull(petId) ?: throw ModelNotFoundException("pet", petId)
+        val mainUser = mainUserRepository.findByIdAndDeletedAtIsNull(userId) ?: throw ModelNotFoundException("user", userId)
+        val petProfile = petProfileRepository.findByIdAndDeletedAtIsNull(petId) ?: throw ModelNotFoundException("pet", petId)
 
         if (petProfile.mainUser != mainUser) {
             throw Exception("해당 유저의 펫프로필이 아닙니다.")
@@ -72,7 +71,7 @@ class PetProfileServiceImpl(
 
     @Transactional
     override fun deletePetProfile(userId: Long, petId: Long) {
-        val mainUser = mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
+        val mainUser = mainUserRepository.findByIdAndDeletedAtIsNull(userId) ?: throw ModelNotFoundException("user", userId)
         val petProfile = petProfileRepository.findByIdAndDeletedAtIsNull(petId) ?: throw ModelNotFoundException("pet", petId)
         if (petProfile.mainUser != mainUser) {
             throw Exception("해당 유저의 펫프로필이 아닙니다.")

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
@@ -44,7 +44,7 @@ class PetProfileServiceImpl(
 
     override fun getUsersPetProfileList(userId: Long): List<PetProfileResponseDTO> {
         val mainUser = mainUserRepository.findByIdAndDeletedAtIsNull(userId) ?: throw ModelNotFoundException("user", userId)
-        val petProfiles = petProfileRepository.findAllByMainUserAndDeletedAtIsNull(mainUser)
+        val petProfiles = petProfileRepository.findAllByMainUserAndDeletedAtIsNull(mainUser).filter{it.disclosure}
         return petProfiles.map { PetProfileResponseDTO.toResponse(it) }
     }
 

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
@@ -1,7 +1,32 @@
 package heispirate.cattower.domain.petProfile.service
 
+import heispirate.cattower.domain.mainUser.repository.MainUserRepository
+import heispirate.cattower.domain.petProfile.dto.CreatePetProfileRequestDTO
+import heispirate.cattower.domain.petProfile.dto.PetProfileResponseDTO
+import heispirate.cattower.domain.petProfile.repository.PetProfileRepository
+import heispirate.cattower.exception.ModelNotFoundException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-class PetProfileServiceImpl : PetProfileService {
+class PetProfileServiceImpl(
+    private val mainUserRepository: MainUserRepository,
+    private val petProfileRepository: PetProfileRepository
+): PetProfileService {
+    @Transactional
+    override fun createPetProfile(
+        userId: Long,
+        createPetProfileRequestDTO: CreatePetProfileRequestDTO
+    ): PetProfileResponseDTO {
+        val mainUser = mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
+        val petProfiles = petProfileRepository.findAllByMainUser(mainUser)
+        if (petProfiles.isNotEmpty() && petProfiles.size >= 3) {
+            throw Exception("펫 프로필 생성은 3개를 초과할 수 없습니다.")
+        }
+        val newPetProfile = createPetProfileRequestDTO.toEntity().apply { this.mainUser = mainUser }
+        mainUser.petProfiles?.add(newPetProfile)
+        val savedPetProfile = petProfileRepository.save(newPetProfile)
+        return PetProfileResponseDTO.toResponse(savedPetProfile)
+    }
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
@@ -8,6 +8,7 @@ import heispirate.cattower.exception.ModelNotFoundException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class PetProfileServiceImpl(
@@ -67,5 +68,17 @@ class PetProfileServiceImpl(
             disclosure = petProfileRequestDTO.disclosure}
         val updatedPetProfile = petProfileRepository.save(petProfile)
         return PetProfileResponseDTO.toResponse(updatedPetProfile)
+    }
+
+    @Transactional
+    override fun deletePetProfile(userId: Long, petId: Long) {
+        val mainUser = mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
+        val petProfile = petProfileRepository.findByIdAndDeletedAtIsNull(petId) ?: throw ModelNotFoundException("pet", petId)
+        if (petProfile.mainUser != mainUser) {
+            throw Exception("해당 유저의 펫프로필이 아닙니다.")
+        }
+        petProfile.deletedAt = LocalDateTime.now()
+        petProfileRepository.save(petProfile)
+
     }
 }

--- a/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/petProfile/service/PetProfileServiceImpl.kt
@@ -69,8 +69,8 @@ class PetProfileServiceImpl(
             healthHistory = petProfileRequestDTO.healthHistory
             profileImageUrl = petProfileRequestDTO.profileImageUrl
             disclosure = petProfileRequestDTO.disclosure}
-        val updatedPetProfile = petProfileRepository.save(petProfile)
-        return PetProfileResponseDTO.toResponse(updatedPetProfile)
+
+        return PetProfileResponseDTO.toResponse(petProfile)
     }
 
     @Transactional
@@ -81,7 +81,6 @@ class PetProfileServiceImpl(
             throw Exception("해당 유저의 펫프로필이 아닙니다.")
         }
         petProfile.deletedAt = LocalDateTime.now()
-        petProfileRepository.save(petProfile)
 
     }
 }

--- a/src/main/kotlin/heispirate/cattower/infra/swagger/SwaggerConfig.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/swagger/SwaggerConfig.kt
@@ -29,8 +29,8 @@ class SwaggerConfig {
             )
             .info(
                 Info()
-                    .title("MoaMoa API")
-                    .description("MoaMoa API schema")
+                    .title("CatTower API")
+                    .description("CatTower API schema")
                     .version("1.0.0"),
             )
     }


### PR DESCRIPTION
## 이슈번호
- closes #6

## 작업 내용
 Pet Profile 생성
 Pet Profile 목록 조회
 Pet Profile 단건 조회
 Pet Profile 수정
 Pet Profile 삭제

## 설명 해주세요
- 사용자는 펫 프로필을 3 개 이하로 생성할 수 있습니다.

- 특정 사용자의 펫 프로필 목록을 조회할 수 있습니다. (삭제나 비공개 상태의 펫 프로필은 목록에 포함되지 않습니다. ) 

- 특정 펫 프로필을 단 건 조회할 수 있습니다. (삭제나 비공개 상태의 펫 프로필은 조회 되지 않습니다. 본인의 펫 프로필인 경우에는 비공개 상태인 펫 프로필도 조회 가능합니다. )

- 특정 펫 프로필을 수정할 수 있습니다. (생성 시 작성했던 모든 요소가 수정 가능합니다. 펫 프로필 수정을 요청한 사용자와 해당 펫이 속한 사용자가 일치해야 합니다. )

- 특정 펫 프로필을 삭제할 수 있습니다. (soft delete 적용. 펫 프로필 삭제를 요청한 사용자와 해당 펫이 속한 사용자가 일치해야 합니다. )


## 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트를 했나요(코드/ 물리)?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 주석을 지웠나요?
