### PR TITLE
Feature/#10/admin

### DIFF
--- a/src/main/kotlin/heispirate/cattower/domain/admin/controller/AdminController.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/controller/AdminController.kt
@@ -1,7 +1,50 @@
 package heispirate.cattower.domain.admin.controller
 
+import heispirate.cattower.domain.admin.dto.AdminRequestDTOver1
+import heispirate.cattower.domain.admin.dto.AdminResponseDTO
+import heispirate.cattower.domain.admin.model.Role
+import heispirate.cattower.domain.admin.service.AdminService
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class AdminController {
+class AdminController(
+    private val adminService: AdminService
+) {
+    @Operation(summary = "어드민 조회", description = "특정 어드민을 조회합니다.")
+    @GetMapping("/admin/{email}")
+    fun getAdmin(@PathVariable email: String): ResponseEntity<AdminResponseDTO> {
+        return ResponseEntity.ok(adminService.getAdmin(email))
+    }
+
+    @Operation(summary = "어드민 목록 조회", description = "어드민 목록을 조회합니다.")
+    @GetMapping("/admin")
+    fun getAllAdmins(): ResponseEntity<List<AdminResponseDTO>> {
+        return ResponseEntity.ok(adminService.getAllAdmin())
+    }
+
+    @Operation(summary = "어드민 생성", description = "유저를 어드민으로 승급합니다.")
+    @PostMapping("/admin/changeUserToAdmin")
+    fun changeUserToAdmin(@RequestBody request: AdminRequestDTOver1): ResponseEntity<AdminResponseDTO> {
+        return ResponseEntity.ok(adminService.changeUserToAdminVersion1(request))
+    }
+
+    @Operation(summary = "어드민 권한 수정", description = "어드민의 권한을 수정합니다.")
+    @PostMapping("/admin/update")
+    fun updateAdmin(@RequestParam email: String, @RequestParam newRole: Role): ResponseEntity<AdminResponseDTO> {
+        return ResponseEntity.ok(adminService.updateAdmin(email, newRole))
+    }
+
+    @Operation(summary = "어드민 권한 삭제", description = "어드민의 권한을 삭제합니다.")
+    @DeleteMapping("/admin/delete/{email}")
+    fun deleteAdmin(@PathVariable email: String): ResponseEntity<Boolean> {
+        return ResponseEntity.ok(adminService.deleteAdmin(email))
+    }
 }

--- a/src/main/kotlin/heispirate/cattower/domain/admin/controller/AdminController.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/controller/AdminController.kt
@@ -2,7 +2,6 @@ package heispirate.cattower.domain.admin.controller
 
 import heispirate.cattower.domain.admin.dto.AdminRequestDTOver1
 import heispirate.cattower.domain.admin.dto.AdminResponseDTO
-import heispirate.cattower.domain.admin.model.Role
 import heispirate.cattower.domain.admin.service.AdminService
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -38,13 +36,13 @@ class AdminController(
 
     @Operation(summary = "어드민 권한 수정", description = "어드민의 권한을 수정합니다.")
     @PostMapping("/admin/update")
-    fun updateAdmin(@RequestParam email: String, @RequestParam newRole: Role): ResponseEntity<AdminResponseDTO> {
-        return ResponseEntity.ok(adminService.updateAdmin(email, newRole))
+    fun updateAdmin(@RequestBody request: AdminRequestDTOver1): ResponseEntity<AdminResponseDTO> {
+        return ResponseEntity.ok(adminService.updateAdminVersion1(request))
     }
 
     @Operation(summary = "어드민 권한 삭제", description = "어드민의 권한을 삭제합니다.")
     @DeleteMapping("/admin/delete/{email}")
-    fun deleteAdmin(@PathVariable email: String): ResponseEntity<Boolean> {
-        return ResponseEntity.ok(adminService.deleteAdmin(email))
+    fun deleteAdmin(@RequestBody request: AdminRequestDTOver1): ResponseEntity<Boolean> {
+        return ResponseEntity.ok(adminService.deleteAdminVersion1(request))
     }
 }

--- a/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminRequestDTOver1.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminRequestDTOver1.kt
@@ -6,4 +6,5 @@ data class AdminRequestDTOver1(
     val role: Role,
     val adminEmail: String,
     val userEmail : String,
+    val verificationCode : String,
 )

--- a/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminRequestDTOver1.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminRequestDTOver1.kt
@@ -6,5 +6,4 @@ data class AdminRequestDTOver1(
     val role: Role,
     val adminEmail: String,
     val userEmail : String,
-    val verificationCode : String,
 )

--- a/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminResponseDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/dto/AdminResponseDTO.kt
@@ -1,14 +1,17 @@
 package heispirate.cattower.domain.admin.dto
 
-import heispirate.cattower.domain.mainUser.model.MainUser
+import heispirate.cattower.domain.admin.model.Admin
+import heispirate.cattower.domain.admin.model.Role
 
 data class AdminResponseDTO(
-    val email: String
+    val email: String,
+    val role : Role
 ) {
     companion object {
-        fun fromMainUser(user: MainUser): AdminResponseDTO {
+        fun fromAdmin(admin: Admin): AdminResponseDTO {
             return AdminResponseDTO(
-                email = user.email
+                email = admin.mainUser.email,
+                role = admin.role
             )
         }
     }

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
@@ -10,8 +10,6 @@ interface AdminService {
 
     fun changeUserToAdminVersion1(request: AdminRequestDTOver1): AdminResponseDTO
 
-    fun signInAdmin(request: AdminRequestDTOver1)
-
     fun updateAdmin(email: String,newRole: Role) : AdminResponseDTO
 
     fun deleteAdmin(email: String) : Boolean

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
@@ -2,6 +2,7 @@ package heispirate.cattower.domain.admin.service
 
 import heispirate.cattower.domain.admin.dto.AdminRequestDTOver1
 import heispirate.cattower.domain.admin.dto.AdminResponseDTO
+import heispirate.cattower.domain.admin.model.Role
 import heispirate.cattower.infra.category.Category
 
 interface AdminService {
@@ -11,11 +12,11 @@ interface AdminService {
 
     fun signInAdmin(request: AdminRequestDTOver1)
 
-    fun updateAdmin(email: String) : AdminResponseDTO
+    fun updateAdmin(email: String,newRole: Role) : AdminResponseDTO
 
     fun deleteAdmin(email: String) : Boolean
 
-    fun getAdmin(email: String)
+    fun getAdmin(email: String) : AdminResponseDTO
 
-    fun getAllAdmin()
+    fun getAllAdmin() : List<AdminResponseDTO>
 }

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
@@ -10,9 +10,9 @@ interface AdminService {
 
     fun changeUserToAdminVersion1(request: AdminRequestDTOver1): AdminResponseDTO
 
-    fun updateAdmin(email: String,newRole: Role) : AdminResponseDTO
+    fun updateAdminVersion1(request: AdminRequestDTOver1) : AdminResponseDTO
 
-    fun deleteAdmin(email: String) : Boolean
+    fun deleteAdminVersion1(request: AdminRequestDTOver1) : Boolean
 
     fun getAdmin(email: String) : AdminResponseDTO
 

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminService.kt
@@ -9,5 +9,13 @@ interface AdminService {
 
     fun changeUserToAdminVersion1(request: AdminRequestDTOver1): AdminResponseDTO
 
-    fun signInAdmin()
+    fun signInAdmin(request: AdminRequestDTOver1)
+
+    fun updateAdmin(email: String) : AdminResponseDTO
+
+    fun deleteAdmin(email: String) : Boolean
+
+    fun getAdmin(email: String)
+
+    fun getAllAdmin()
 }

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminServiceImpl.kt
@@ -43,11 +43,6 @@ class AdminServiceImpl(
     }
 
     @Transactional
-    override fun signInAdmin(request: AdminRequestDTOver1) {
-        val admin = adminRepository.findByMainUserEmail(request.adminEmail) ?: throw IllegalArgumentException("이메일을 찾을수 없습니다")
-    }
-
-    @Transactional
     override fun updateAdmin(email: String, newRole: Role): AdminResponseDTO {
         val admin = adminRepository.findByMainUserEmail(email) ?: throw IllegalArgumentException("이메일을 찾을수 없습니다")
         admin.role = newRole

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminServiceImpl.kt
@@ -8,6 +8,7 @@ import heispirate.cattower.domain.admin.repository.AdminRepository
 import heispirate.cattower.domain.mainUser.repository.MainUserRepository
 import heispirate.cattower.domain.petProfile.model.PetProfile
 import heispirate.cattower.domain.post.model.Post
+import heispirate.cattower.exception.ModelNotFoundException
 import heispirate.cattower.infra.category.Category
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -43,9 +44,24 @@ class AdminServiceImpl(
     }
 
     @Transactional
-    override fun signInAdmin() {
-        //TODO : 카카오톡 알림 시스템을 이용하여 인증 계획중...
-        //TODO : 카카오톡 알림문자 수신  -> 인증번호 입력 -> 이 과정을 통과하면 admin기능 활성화 ...?
+    override fun signInAdmin(request: AdminRequestDTOver1) {
+        val admin = adminRepository.findByMainUserEmail(request.adminEmail) ?: throw IllegalArgumentException("이메일을 찾을수 없습니다")
+    }
+
+    override fun updateAdmin(email: String): AdminResponseDTO {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteAdmin(email: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAdmin(email: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAllAdmin() {
+        TODO("Not yet implemented")
     }
 
     // 예시 적용을 위한 펫 프로필 확인

--- a/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/admin/service/AdminServiceImpl.kt
@@ -8,7 +8,6 @@ import heispirate.cattower.domain.admin.repository.AdminRepository
 import heispirate.cattower.domain.mainUser.repository.MainUserRepository
 import heispirate.cattower.domain.petProfile.model.PetProfile
 import heispirate.cattower.domain.post.model.Post
-import heispirate.cattower.exception.ModelNotFoundException
 import heispirate.cattower.infra.category.Category
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -48,20 +47,28 @@ class AdminServiceImpl(
         val admin = adminRepository.findByMainUserEmail(request.adminEmail) ?: throw IllegalArgumentException("이메일을 찾을수 없습니다")
     }
 
-    override fun updateAdmin(email: String): AdminResponseDTO {
-        TODO("Not yet implemented")
+    @Transactional
+    override fun updateAdmin(email: String, newRole: Role): AdminResponseDTO {
+        val admin = adminRepository.findByMainUserEmail(email) ?: throw IllegalArgumentException("이메일을 찾을수 없습니다")
+        admin.role = newRole
+        return AdminResponseDTO.fromMainUser(admin.mainUser)
     }
 
+    @Transactional
     override fun deleteAdmin(email: String): Boolean {
-        TODO("Not yet implemented")
+        val admin = adminRepository.findByMainUserEmail(email) ?: throw IllegalArgumentException("이메일을 찾을수 없습니다")
+        adminRepository.delete(admin)
+        return true
     }
 
-    override fun getAdmin(email: String) {
-        TODO("Not yet implemented")
+    override fun getAdmin(email: String): AdminResponseDTO {
+        val admin = adminRepository.findByMainUserEmail(email) ?: throw IllegalArgumentException("이메일을 찾을수 없습니다")
+        return AdminResponseDTO.fromMainUser(admin.mainUser)
     }
 
-    override fun getAllAdmin() {
-        TODO("Not yet implemented")
+    override fun getAllAdmin(): List<AdminResponseDTO> {
+        val admins = adminRepository.findAll()
+        return admins.map { admin -> AdminResponseDTO.fromMainUser(admin.mainUser) }
     }
 
     // 예시 적용을 위한 펫 프로필 확인

--- a/src/main/kotlin/heispirate/cattower/domain/sms/controller/SMSController.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/sms/controller/SMSController.kt
@@ -6,6 +6,7 @@ import net.nurigo.sdk.message.response.SingleMessageSentResponse
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 
@@ -17,5 +18,10 @@ class SMSController(
     @PostMapping("/send-one")
     fun sendOne(@RequestBody request: SendSMSRequestDTO): SingleMessageSentResponse? {
         return smsService.sendOne(request.to, request.text)
+    }
+
+    @PostMapping("/send-verification-code")
+    fun sendVerificationCode(@RequestParam to: String): SingleMessageSentResponse? {
+        return smsService.sendVerificationCode(to)
     }
 }

--- a/src/main/kotlin/heispirate/cattower/domain/sms/service/SMSService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/sms/service/SMSService.kt
@@ -4,4 +4,6 @@ import net.nurigo.sdk.message.response.SingleMessageSentResponse
 
 interface SMSService {
     fun sendOne(to: String, text: String): SingleMessageSentResponse?
+
+    fun sendVerificationCode(to: String): SingleMessageSentResponse?
 }

--- a/src/main/kotlin/heispirate/cattower/domain/sms/service/SMSServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/sms/service/SMSServiceImpl.kt
@@ -2,6 +2,7 @@ package heispirate.cattower.domain.sms.service
 
 import heispirate.cattower.domain.sms.model.SMS
 import heispirate.cattower.domain.sms.repository.SMSRepository
+import kotlin.random.Random
 import net.nurigo.sdk.message.model.Message
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest
 import net.nurigo.sdk.message.response.SingleMessageSentResponse
@@ -32,5 +33,11 @@ class SMSServiceImpl(
         }
 
         return response
+    }
+
+    override fun sendVerificationCode(to: String): SingleMessageSentResponse? {
+        val verificationCode = Random.nextInt(100000, 999999).toString()
+        val messageText = "인증 코드는 [$verificationCode]입니다"
+        return sendOne(to, messageText)
     }
 }


### PR DESCRIPTION
## 이슈번호
- closes #10 

## 작업 내용
- update 기능 추가
- delete 기능 추가
- 전체 read기능 추가
- 단일 read기능 추가
- dto 컴패니언 오브젝트 객체 수정
- admin 로그인시 SMS인증 작업 보류

## 설명 해주세요
- update,delete 기능을 추가 하였습니다, create와 같이 role이 ADMIN이여야만 가능합니다. version1 에서는 토큰등이 구현되어 있지 않기 때문에 ADMIN의 role을 가진 email을 입력받아 처리하도록 로직을 구현하였습니다.
- 단일 조회와 전체 조회를 추가하였습니다.
- 각 기능에 맞는 컨트롤러를 추가하였습니다.
- dto에 컴패니언 오브젝트를 수정하여, return시 해당 email이 가지는 role이 무엇인지 확인 가능하게 수정하였습니다.
- *중요* admin의 role을 가진 email이 로그인 할시에 SMS인증을 작업하려 하였으나, 해당 코드를 admin에서 처리해야 할지 아니면 mainUser에서 처리해야 할지 아직 로그인 방식이 구현되지 않아 작업을 보류하였습니다. 또한 해당 작업은 Front 작업과 병행하면서 하는게 좋다 생각하여 보류 한 점도 있습니다.

## 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트를 했나요(코드/ 물리)? ->swagger 테스트 / 테스트 코드 X
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 주석을 지웠나요?
