### PR TITLE
AuthCode 리팩토링

### DIFF
--- a/src/main/kotlin/heispirate/cattower/domain/authCode/service/AuthCodeServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/authCode/service/AuthCodeServiceImpl.kt
@@ -3,6 +3,7 @@ package heispirate.cattower.domain.authCode.service
 import heispirate.cattower.domain.authCode.dto.AuthResponseDTO
 import heispirate.cattower.domain.authCode.model.AuthCode
 import heispirate.cattower.domain.authCode.repository.AuthCodeRepository
+import heispirate.cattower.infra.email.EmailService
 import heispirate.cattower.infra.email.EmailUtility
 import jakarta.transaction.Transactional
 import java.time.LocalDateTime
@@ -13,12 +14,12 @@ import org.springframework.stereotype.Service
 @Service
 class AuthCodeServiceImpl(
     private val authCodeRepository: AuthCodeRepository,
-    private val emailUtility: EmailUtility
+    private val emailService: EmailService
 ) : AuthCodeService {
     @Transactional
     override fun sendAuthEmail(email: String): AuthResponseDTO {
         val randomCode = generateCode(email)
-        emailUtility.sendEmail(
+        emailService.sendEmail(
             email = email,
             subject = "캣타워 인증 코드 입니다",
             text = "인증코드 : $randomCode"

--- a/src/main/kotlin/heispirate/cattower/infra/email/EmailService.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/email/EmailService.kt
@@ -1,0 +1,5 @@
+package heispirate.cattower.infra.email
+
+interface EmailService {
+    fun sendEmail(email:String, subject: String,text:String)
+}

--- a/src/main/kotlin/heispirate/cattower/infra/email/EmailUtility.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/email/EmailUtility.kt
@@ -1,9 +1,5 @@
 package heispirate.cattower.infra.email
 
-import heispirate.cattower.domain.authCode.model.AuthCode
-import heispirate.cattower.domain.authCode.repository.AuthCodeRepository
-import java.time.LocalDateTime
-import java.util.UUID
 import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.stereotype.Component
@@ -11,9 +7,9 @@ import org.springframework.stereotype.Component
 @Component
 class EmailUtility(
     val javaMailSender: JavaMailSender,
-) {
+):EmailService {
 
-    fun sendEmail(email:String, subject: String,text:String){
+    override fun sendEmail(email:String, subject: String,text:String){
 
         val message = SimpleMailMessage()
         message.setTo(email)

--- a/src/main/kotlin/heispirate/cattower/scheduler/SchedulerService.kt
+++ b/src/main/kotlin/heispirate/cattower/scheduler/SchedulerService.kt
@@ -7,12 +7,13 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 @Component
-class AuthCodeCleaner(
+class SchedulerService(
     private val authCodeService: AuthCodeService,
-) {
+){
     @Scheduled(cron = "0 0 0 * * *")
     fun cleanAuthCode() {
         val zeroHour = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
             authCodeService.deleteAuthCode(zeroHour)
     }
+
 }


### PR DESCRIPTION
## 이슈번호
- closes #25 

## 작업 내용
- 메일 서비스 추상화 및 인증코드 삭제클래스 공용클래스로 이름변경

## 설명 해주세요

DI / IOC 를 공부하면서 문득 최근에 작업했던 내용들이 떠올라서 간단하게 수정 해보았습니다 

추상화를 통한 이점을 가지고 가면 매개변수가 변경되지 않는 이상 서비스단에서 메일 서비스를 사용할 때 의존역전에 부합하다고 생각이 들었습니다 

코드클리너 클래스를 스케줄러 서비스로 바꿔 보았습니다 

스케줄러가 각각 독립된 클래스로 

1. 인증코드삭제 스케줄러 

2. 오래된 탈퇴 회원정보 스케줄러

가 있을 경우 

정보삭제는 서비스에 구현하고 스케줄러는 단순 호출만 해주는 개념으로 가는 설계를 해 보았습니다 

근거는 각각의 스케줄링 기능이 무겁고 복잡하다면 별도의 스케줄링클래스로 관리하는게 맞으나 스케줄링 서비스가 그리 많지 않고 통합관리의 이점과 비즈니스 로직은 각각의 서비스에서 책임을 가져가는게 좋아보여서 살짝 리팩토링 해보았습니다.

 의견 제시해주시면 감사하겠습니다 
(메일서비스 추상화는 백번 생각해도 맞는데 스케줄러통합은 약간 책임을 누구에게 주느냐라서 좀 어려움 의견제시부탁 ! ) 


## 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트를 했나요(코드/ 물리)?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 주석을 지웠나요?
