### PR TITLE
Feature/#24/post crud

### DIFF
--- a/src/main/kotlin/heispirate/cattower/CatTowerApplication.kt
+++ b/src/main/kotlin/heispirate/cattower/CatTowerApplication.kt
@@ -1,6 +1,5 @@
 package heispirate.cattower
 
-import kotlinx.datetime.TimeZone
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 import org.springframework.boot.runApplication

--- a/src/main/kotlin/heispirate/cattower/CatTowerApplication.kt
+++ b/src/main/kotlin/heispirate/cattower/CatTowerApplication.kt
@@ -4,11 +4,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @EnableScheduling
 @SpringBootApplication(exclude = [SecurityAutoConfiguration::class])
 @EnableJpaAuditing
+@EnableAsync
 class CatTowerApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/heispirate/cattower/domain/post/controller/PostController.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/controller/PostController.kt
@@ -1,7 +1,79 @@
 package heispirate.cattower.domain.post.controller
 
+import heispirate.cattower.domain.post.dto.PostRequestDTOv1
+import heispirate.cattower.domain.post.dto.PostResponseDTOv1
+import heispirate.cattower.domain.post.service.PostService
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class PostController {
+@RequestMapping("/posts")
+class PostController(
+    private val postService: PostService
+) {
+
+    @Operation(summary = "글 생성", description = "사용자가 새로운 글을 생성 합니다.")
+    @PostMapping("/{userId}/petProfile/{petProfileId}")
+    fun createPost(
+        @PathVariable userId: Long,
+        @PathVariable petProfileId: Long,
+        @RequestBody request: PostRequestDTOv1
+    ): ResponseEntity<PostResponseDTOv1> {
+        val postResponse = postService.createPostV1(request, userId, petProfileId)
+        return ResponseEntity.ok(postResponse)
+    }
+
+    @Operation(summary = "글 삭제", description = "사용자가 자신의 글을 삭제 합니다.")
+    @DeleteMapping("/{userId}/{postId}")
+    fun deletePostV1(
+        @PathVariable postId: Long,
+        @PathVariable userId: Long,
+    ): ResponseEntity<Boolean> {
+        val result = postService.deletePostV1(postId, userId)
+        return ResponseEntity.ok(result)
+    }
+
+    @Operation(summary = "단일 글 조회", description = "단일 글을 조회 합니다.")
+    @GetMapping("/{postId}")
+    fun getPostV1(
+        @PathVariable postId: Long
+    ): ResponseEntity<PostResponseDTOv1> {
+        val postResponse = postService.getPostV1(postId)
+        return ResponseEntity.ok(postResponse)
+    }
+
+    @Operation(summary = "전체 글 페이징 조회", description = "전체 글을 페이징 조회 합니다.")
+    @GetMapping
+    fun getAllPostsV1(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "5") size: Int
+    ): ResponseEntity<Page<PostResponseDTOv1>> {
+        val pageable: Pageable = PageRequest.of(page, size)
+        val postPage = postService.getAllPostsV1(pageable)
+        return ResponseEntity.ok(postPage)
+    }
+
+    @Operation(summary = "펫 프로필 기준 글 페이징 조회", description = "펫 프로필로 작성한 글 전체를 조회 합니다.")
+    @GetMapping("/pet/{petProfileId}")
+    fun getPostsByPetProfileV1(
+        @PathVariable petProfileId: Long,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "5") size: Int
+    ): ResponseEntity<Page<PostResponseDTOv1>> {
+        val pageable: Pageable = PageRequest.of(page, size)
+        val postPage = postService.getPostsByPetProfileV1(petProfileId, pageable)
+        return ResponseEntity.ok(postPage)
+    }
+
 }

--- a/src/main/kotlin/heispirate/cattower/domain/post/controller/PostController.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/controller/PostController.kt
@@ -25,7 +25,7 @@ class PostController(
 
     @Operation(summary = "글 생성", description = "사용자가 새로운 글을 생성 합니다.")
     @PostMapping("/{userId}/petProfile/{petProfileId}")
-    fun createPost(
+    fun createPostV1(
         @PathVariable userId: Long,
         @PathVariable petProfileId: Long,
         @RequestBody request: PostRequestDTOv1

--- a/src/main/kotlin/heispirate/cattower/domain/post/dto/PostRequestDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/dto/PostRequestDTO.kt
@@ -1,6 +1,0 @@
-package heispirate.cattower.domain.post.dto
-
-//data class PostRequestDTO(
-//    val
-//    //TODO 필요한 한 것 채워넣기
-//)

--- a/src/main/kotlin/heispirate/cattower/domain/post/dto/PostRequestDTOv1.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/dto/PostRequestDTOv1.kt
@@ -1,0 +1,26 @@
+package heispirate.cattower.domain.post.dto
+
+import heispirate.cattower.domain.petProfile.model.PetProfile
+import heispirate.cattower.domain.post.model.Post
+import heispirate.cattower.domain.post.model.SubCategory
+import heispirate.cattower.infra.category.Category
+
+data class PostRequestDTOv1(
+    val title: String,
+    val content: String,
+    val category: Category,
+    val subCategory: SubCategory,
+) {
+    fun toEntity(petProfile: PetProfile): Post {
+        return Post(
+            title = title,
+            content = content,
+            writer = petProfile.name,
+            category = category,
+            imageUrl = null,
+            likeCounts = 0,
+            petProfile = petProfile,
+            subCategory = subCategory
+        )
+    }
+}

--- a/src/main/kotlin/heispirate/cattower/domain/post/dto/PostResponseDTOv1.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/dto/PostResponseDTOv1.kt
@@ -1,0 +1,25 @@
+package heispirate.cattower.domain.post.dto
+
+import heispirate.cattower.domain.post.model.Post
+import heispirate.cattower.domain.post.model.SubCategory
+import heispirate.cattower.infra.category.Category
+
+data class PostResponseDTOv1(
+    val title: String,
+    val content: String,
+    val writer: String,
+    val category: Category,
+    val subCategory: SubCategory
+) {
+    companion object {
+        fun fromPost(post: Post): PostResponseDTOv1 {
+            return PostResponseDTOv1(
+                title = post.title,
+                content = post.content,
+                writer = post.writer,
+                category = post.category,
+                subCategory = post.subCategory
+            )
+        }
+    }
+}

--- a/src/main/kotlin/heispirate/cattower/domain/post/repository/PostRepository.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/repository/PostRepository.kt
@@ -1,7 +1,11 @@
 package heispirate.cattower.domain.post.repository
 
 import heispirate.cattower.domain.post.model.Post
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface PostRepository : JpaRepository<Post,Long> , CustomPostRepository{
+
+    fun findByPetProfileId(petProfileId: Long, pageable: Pageable): Page<Post>?
 }

--- a/src/main/kotlin/heispirate/cattower/domain/post/service/PostService.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/service/PostService.kt
@@ -1,4 +1,19 @@
 package heispirate.cattower.domain.post.service
 
+import heispirate.cattower.domain.post.dto.PostRequestDTOv1
+import heispirate.cattower.domain.post.dto.PostResponseDTOv1
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
 interface PostService {
+
+    fun createPostV1(request : PostRequestDTOv1,userId : Long, petProfileId :Long) : PostResponseDTOv1
+
+    fun deletePostV1(postId: Long, userId: Long): Boolean
+
+    fun getPostV1(postId: Long): PostResponseDTOv1
+
+    fun getAllPostsV1(pageable: Pageable): Page<PostResponseDTOv1>
+
+    fun getPostsByPetProfileV1(petProfileId: Long, pageable: Pageable): Page<PostResponseDTOv1>
 }

--- a/src/main/kotlin/heispirate/cattower/domain/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/post/service/PostServiceImpl.kt
@@ -1,7 +1,86 @@
 package heispirate.cattower.domain.post.service
 
+import heispirate.cattower.domain.mainUser.repository.MainUserRepository
+import heispirate.cattower.domain.petProfile.repository.PetProfileRepository
+import heispirate.cattower.domain.post.dto.PostRequestDTOv1
+import heispirate.cattower.domain.post.dto.PostResponseDTOv1
+import heispirate.cattower.domain.post.repository.PostRepository
+import heispirate.cattower.event.ExpChangeEvent
+import heispirate.cattower.event.ExpChangeType
+import heispirate.cattower.exception.ModelNotFoundException
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-class PostServiceImpl : PostService {
+class PostServiceImpl(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val postRepository: PostRepository,
+    private val petProfileRepository: PetProfileRepository,
+    private val mainUserRepository: MainUserRepository,
+) : PostService {
+
+    @Transactional
+    override fun createPostV1(request: PostRequestDTOv1, userId: Long,petProfileId:Long): PostResponseDTOv1 {
+        val mainUser = mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user",userId)
+        val petProfile = petProfileRepository.findByIdOrNull(petProfileId) ?: throw ModelNotFoundException("pet",petProfileId)
+
+        if (petProfile.mainUser.id != mainUser.id) {
+            throw IllegalArgumentException("유저와 펫의 주인이 다릅니다")
+        }
+
+        val postEntity = request.toEntity(petProfile)
+        val savePost = postRepository.save(postEntity)
+
+        val expChangeEvent = ExpChangeEvent(
+            userId = mainUser.id ?: throw IllegalStateException("userId가 null 입니다"),
+            exp = 199,  // 경험치 양은 예시 입니다.
+            type = ExpChangeType.GAIN
+        )
+        applicationEventPublisher.publishEvent(expChangeEvent)
+
+        return PostResponseDTOv1.fromPost(savePost)
+    }
+
+    @Transactional
+    override fun deletePostV1(postId: Long, userId: Long): Boolean {
+        val mainUser = mainUserRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
+        val post = postRepository.findByIdOrNull(postId) ?: throw ModelNotFoundException("post", postId)
+
+        if (post.petProfile.mainUser.id != mainUser.id) {
+            throw IllegalArgumentException("사용자와 게시글 작성자의 소유주가 다릅니다")
+        }
+
+        postRepository.delete(post)
+
+        val expChangeEvent = ExpChangeEvent(
+            userId = mainUser.id ?: throw IllegalStateException("userId가 null 입니다"),
+            exp = 180,  // 경험치 양은 예시입니다.
+            type = ExpChangeType.LOSE
+        )
+        applicationEventPublisher.publishEvent(expChangeEvent)
+
+        return true
+    }
+
+    @Transactional
+    override fun getPostV1(postId: Long): PostResponseDTOv1 {
+        val post = postRepository.findById(postId).orElseThrow { ModelNotFoundException("post", postId) }
+        return PostResponseDTOv1.fromPost(post)
+    }
+
+    @Transactional
+    override fun getAllPostsV1(pageable: Pageable): Page<PostResponseDTOv1> {
+        val posts = postRepository.findAll(pageable)
+        return posts.map { post -> PostResponseDTOv1.fromPost(post) }
+    }
+
+    @Transactional
+    override fun getPostsByPetProfileV1(petProfileId: Long, pageable: Pageable): Page<PostResponseDTOv1> {
+        val posts = postRepository.findByPetProfileId(petProfileId, pageable) ?: throw ModelNotFoundException("post",petProfileId)
+        return posts.map { post -> PostResponseDTOv1.fromPost(post) }
+    }
 }

--- a/src/main/kotlin/heispirate/cattower/event/ExpChangeEvent.kt
+++ b/src/main/kotlin/heispirate/cattower/event/ExpChangeEvent.kt
@@ -1,0 +1,11 @@
+package heispirate.cattower.event
+
+data class ExpChangeEvent(
+    val userId: Long,
+    val exp: Int,
+    val type: ExpChangeType
+)
+
+enum class ExpChangeType {
+    GAIN, LOSE
+}

--- a/src/main/kotlin/heispirate/cattower/event/ExpChangeListener.kt
+++ b/src/main/kotlin/heispirate/cattower/event/ExpChangeListener.kt
@@ -1,0 +1,20 @@
+package heispirate.cattower.event
+
+import heispirate.cattower.infra.level.service.LevelService
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class ExpChangeListener(private val levelService: LevelService) {
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleExpChangeEvent(event: ExpChangeEvent) {
+        when (event.type) {
+            ExpChangeType.GAIN -> levelService.gainExp(event.exp, event.userId)
+            ExpChangeType.LOSE -> levelService.loseExp(event.exp, event.userId)
+        }
+    }
+}

--- a/src/main/kotlin/heispirate/cattower/infra/level/dto/ExperienceDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/level/dto/ExperienceDTO.kt
@@ -1,4 +1,4 @@
-package heispirate.cattower.domain.level.dto
+package heispirate.cattower.infra.level.dto
 
 import heispirate.cattower.domain.mainUser.model.MainUser
 

--- a/src/main/kotlin/heispirate/cattower/infra/level/dto/LevelResponseDTO.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/level/dto/LevelResponseDTO.kt
@@ -1,4 +1,4 @@
-package heispirate.cattower.domain.level.dto
+package heispirate.cattower.infra.level.dto
 
 import heispirate.cattower.domain.mainUser.model.MainUser
 

--- a/src/main/kotlin/heispirate/cattower/infra/level/service/LevelService.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/level/service/LevelService.kt
@@ -1,6 +1,6 @@
-package heispirate.cattower.domain.level.service
+package heispirate.cattower.infra.level.service
 
-import heispirate.cattower.domain.level.dto.LevelResponseDTO
+import heispirate.cattower.infra.level.dto.LevelResponseDTO
 
 interface LevelService {
 

--- a/src/main/kotlin/heispirate/cattower/infra/level/service/LevelServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/level/service/LevelServiceImpl.kt
@@ -1,7 +1,7 @@
-package heispirate.cattower.domain.level.service
+package heispirate.cattower.infra.level.service
 
-import heispirate.cattower.domain.level.dto.ExperienceDTO
-import heispirate.cattower.domain.level.dto.LevelResponseDTO
+import heispirate.cattower.infra.level.dto.ExperienceDTO
+import heispirate.cattower.infra.level.dto.LevelResponseDTO
 import heispirate.cattower.domain.mainUser.model.MainUser
 import heispirate.cattower.domain.mainUser.repository.MainUserRepository
 import heispirate.cattower.exception.ModelNotFoundException

--- a/src/test/kotlin/heispirate/cattower/levelTest/ExpTest.kt
+++ b/src/test/kotlin/heispirate/cattower/levelTest/ExpTest.kt
@@ -1,7 +1,7 @@
 package heispirate.cattower.levelTest
 
 
-import heispirate.cattower.domain.level.service.LevelServiceImpl
+import heispirate.cattower.infra.level.service.LevelServiceImpl
 import heispirate.cattower.domain.mainUser.model.MainUser
 import heispirate.cattower.domain.mainUser.repository.MainUserRepository
 import io.kotest.matchers.shouldBe


### PR DESCRIPTION
## 이슈번호
- closes #24 

## 작업 내용
- post 작성 ,삭제 ,조회 기능 추가
- 경험치 증감 이벤트 생성
- level 로직 패키지 구조 변경

## 설명 해주세요
- post 작성,삭제,조회 기능을 userId와 petProfileId 를 매개변수로 사용하는 v1으로 구현
- 컨트롤러의 api경로가 회의때와 다르게 변경
- event 패키지를 domain 과 동등한 위치에 생성
- 경험치 증감 event를 생성하여, 추후 다른 로직(ex:댓글)에서도 바로 사용 할 수 있도록 생성
- level 로직을 domain에서 infra 로 이동 -> 하나의 domain이라기 보단 event로 다른 domain에서 사용 되는 역할을 가지고 있어서 infra에서 관리하는게 좋다고 생각되어 변경

## 리뷰어 분들에게 질문
- @PathVariable을 사용한 이유는 게시물 작성시 user와 pet의 id값이 필수라 생각해서 사용 하였습니다. 다만 이 경우 경로가 
/{userId}/petProfile/{petProfileId} 이런식으로 늘어나게 되는데, V1에서 경로가 합당한지?
- level을 infra쪽에서 관리하는게 합리적인 구조인지? 아니면 다른 더 합리적인 구조가 있을지?

## 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트를 했나요(코드/ 물리)? -> swagger api 호출 테스트 및 이벤트 발행 확인
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 주석을 지웠나요?
