### PR TITLE
Feature/#09/auth code

### DIFF
--- a/src/main/kotlin/heispirate/cattower/domain/authCode/repository/AuthCodeRepository.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/authCode/repository/AuthCodeRepository.kt
@@ -12,7 +12,7 @@ interface AuthCodeRepository : JpaRepository<AuthCode,Long> , CustomAuthCodeRepo
 
     @Modifying
     @Query("DELETE FROM AuthCode a WHERE a.expirationTime < :zeroHour")
-    fun deleteByExpirationTime(zeroHour:LocalDateTime): Int
+    fun deleteByExpirationTime(zeroHour:LocalDateTime)
 
 
 }

--- a/src/main/kotlin/heispirate/cattower/domain/authCode/service/AuthCodeServiceImpl.kt
+++ b/src/main/kotlin/heispirate/cattower/domain/authCode/service/AuthCodeServiceImpl.kt
@@ -3,6 +3,7 @@ package heispirate.cattower.domain.authCode.service
 import heispirate.cattower.domain.authCode.dto.AuthResponseDTO
 import heispirate.cattower.domain.authCode.model.AuthCode
 import heispirate.cattower.domain.authCode.repository.AuthCodeRepository
+import heispirate.cattower.infra.email.EmailService
 import heispirate.cattower.infra.email.EmailUtility
 import jakarta.transaction.Transactional
 import java.time.LocalDateTime
@@ -13,12 +14,12 @@ import org.springframework.stereotype.Service
 @Service
 class AuthCodeServiceImpl(
     private val authCodeRepository: AuthCodeRepository,
-    private val emailUtility: EmailUtility
+    private val emailService: EmailService
 ) : AuthCodeService {
     @Transactional
     override fun sendAuthEmail(email: String): AuthResponseDTO {
         val randomCode = generateCode(email)
-        emailUtility.sendEmail(
+        emailService.sendEmail(
             email = email,
             subject = "캣타워 인증 코드 입니다",
             text = "인증코드 : $randomCode"

--- a/src/main/kotlin/heispirate/cattower/infra/email/EmailService.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/email/EmailService.kt
@@ -1,0 +1,5 @@
+package heispirate.cattower.infra.email
+
+interface EmailService {
+    fun sendEmail(email:String, subject: String,text:String)
+}

--- a/src/main/kotlin/heispirate/cattower/infra/email/EmailUtility.kt
+++ b/src/main/kotlin/heispirate/cattower/infra/email/EmailUtility.kt
@@ -1,9 +1,5 @@
 package heispirate.cattower.infra.email
 
-import heispirate.cattower.domain.authCode.model.AuthCode
-import heispirate.cattower.domain.authCode.repository.AuthCodeRepository
-import java.time.LocalDateTime
-import java.util.UUID
 import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.stereotype.Component
@@ -11,9 +7,9 @@ import org.springframework.stereotype.Component
 @Component
 class EmailUtility(
     val javaMailSender: JavaMailSender,
-) {
+):EmailService {
 
-    fun sendEmail(email:String, subject: String,text:String){
+    override fun sendEmail(email:String, subject: String,text:String){
 
         val message = SimpleMailMessage()
         message.setTo(email)

--- a/src/main/kotlin/heispirate/cattower/scheduler/AuthCodeScheduler.kt
+++ b/src/main/kotlin/heispirate/cattower/scheduler/AuthCodeScheduler.kt
@@ -7,7 +7,7 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 @Component
-class SchedulerService(
+class AuthCodeScheduler(
     private val authCodeService: AuthCodeService,
 ){
     @Scheduled(cron = "0 0 0 * * *")

--- a/src/main/kotlin/heispirate/cattower/scheduler/SchedulerService.kt
+++ b/src/main/kotlin/heispirate/cattower/scheduler/SchedulerService.kt
@@ -7,12 +7,13 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 @Component
-class AuthCodeCleaner(
+class SchedulerService(
     private val authCodeService: AuthCodeService,
-) {
+){
     @Scheduled(cron = "0 0 0 * * *")
     fun cleanAuthCode() {
         val zeroHour = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
             authCodeService.deleteAuthCode(zeroHour)
     }
+
 }


### PR DESCRIPTION
## 이슈번호
- closes #28 
- 
## 작업 내용
- 리팩토링 한다고 건드린 커밋내역 원상복구 
- 커스텀 쿼리 메서드 반환형 Int -> Unit 으로 변경

## 설명 해주세요
-  앞 전에 리팩토링 추상화 한다고 커밋해놓은 내역 조금 아쉬워서 롤백 시켰습니다( 원상복구 )
- AuthCodeRepository 에 있는deleteByExpirationTime() 메서드 반환형이 Int 인데 행 삭제 갯수 확인하려 했던걸 까먹고 안지웠습니다 
-  신경써서 작업하도록 하겠습니다  죄송합니다 

### 추가사항

![트랜잭션과 스케줄드 어노테이션 붙은 메서드](https://github.com/user-attachments/assets/0e090eba-96aa-4a28-bc57-d443e7de17c6)
- scheduler 에서 흐름이 scheduler -> service -> repository 이렇게 호출 하는데 테스트 다시 해보니까 첨부한 이미지 처럼 해도 작동합니다
- 특정 상황에만 db반영이 안되고 scheduler or repository 에 @Transactional 걸려만 있으면 빌드할때 오류안나고 잘 작동합니다
- 근데 그 특정상황을 정확하게는 잘 모르겠으나 정보를 종합해보면 아마 외래키가 걸려있을때 연결된 특정 엔티티가 준영속 상태라 엔티티매니저를 새로 정의하여 사용/ 엔티티 제약조건변경하는 어노테이션 / 중간에 클래스에서 한번더 호출 등등 방법이 있던데 서비스에서 호출이 제일 정배인거 같습니다 
- 결론은 현재 코드 수정 따로 하지않고 놔두겠습니다




## 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트를 했나요(코드/ 물리)?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 주석을 지웠나요?
